### PR TITLE
Feat: Npm provenance setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS file for @girs/types repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Critical infrastructure files - require review from core maintainers
+/.github/** @JumpLink @ewlsh
+/package.json @JumpLink @ewlsh
+
+# Package configurations - critical for npm releases
+/**/package.json @JumpLink @ewlsh
+
+# CODEOWNERS file itself - only core maintainers can change
+/.github/CODEOWNERS @JumpLink @ewlsh
+

--- a/.github/release-script/.gitignore
+++ b/.github/release-script/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/.github/release-script/package-lock.json
+++ b/.github/release-script/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "release-script",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "release-script",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.3.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/release-script/package.json
+++ b/.github/release-script/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "release-script",
+  "version": "1.0.0",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "MIT",
+  "description": "",
+  "devDependencies": {
+    "@types/node": "^24.3.0"
+  }
+}

--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -1,0 +1,336 @@
+import * as fsAsync from "node:fs/promises"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as child_process from "node:child_process"
+
+type MatchFn = (file: string) => boolean
+
+async function getAllFilesMatching(
+	folder: string,
+	fn: MatchFn
+): Promise<string[]> {
+	if (!path.isAbsolute(folder)) {
+		throw new Error(
+			`Implementation error: not an absolute path: '${folder}'`
+		)
+	}
+
+	const result: string[] = []
+
+	const subFiles = await fsAsync.readdir(folder)
+
+	for (const file_ of subFiles) {
+		const file = path.join(folder, file_)
+
+		const stat = await fsAsync.stat(file)
+		if (stat.isDirectory()) {
+			const subResult = await getAllFilesMatching(file, fn)
+			result.push(...subResult)
+		} else {
+			if (fn(file)) {
+				result.push(file)
+			}
+		}
+	}
+
+	return result
+}
+
+interface Package {
+	name: string
+	version: string
+	rootFolder: string
+}
+
+interface PackageInfo {
+	name: string
+	version: string
+}
+
+interface PackageInfoRaw extends Record<string, unknown> {
+	name?: string | undefined
+	version?: string | undefined
+}
+
+async function getPackageInfo(packageFile: string): Promise<PackageInfo> {
+	const packageInfoRaw = await (
+		await fsAsync.readFile(packageFile)
+	).toString()
+
+	const packageInfo = JSON.parse(packageInfoRaw) as PackageInfoRaw
+
+	if (typeof packageInfo.name !== "string") {
+		throw new Error(`Invalid package.json: ${packageFile}`)
+	}
+
+	if (typeof packageInfo.version !== "string") {
+		throw new Error(`Invalid package.json: ${packageFile}`)
+	}
+
+	return { name: packageInfo.name, version: packageInfo.version }
+}
+
+async function getPackage(packageFile: string): Promise<Package> {
+	const packageInfo = await getPackageInfo(packageFile)
+
+	const rootFolder = path.dirname(packageFile)
+
+	return { name: packageInfo.name, version: packageInfo.version, rootFolder }
+}
+
+interface NPMVersionInfo {
+	name: string
+	version: string
+}
+
+interface NPMData {
+	versions: Record<string, NPMVersionInfo | undefined>
+}
+
+type NpmStatus = "unpublished" | "published"
+
+function getNormalizedRegistryUrl(url: string): string {
+	let result = url
+	if (!result.startsWith("http")) {
+		result = `https://${result}`
+	}
+
+	if (!result.endsWith("/")) {
+		result += "/"
+	}
+
+	return result
+}
+
+async function getNpmStatus(
+	pkg: Package,
+	registry: string
+): Promise<NpmStatus> {
+	const url = `${registry}${pkg.name}`
+
+	try {
+		const res = await fetch(url)
+		if (!res.ok)
+			throw new Error(
+				`Failed to fetch package info for package ${pkg.name}: Status Code ${res.status}`
+			)
+
+		const data = (await res.json()) as NPMData
+
+		const versionInfo = data.versions[pkg.version]
+
+		if (versionInfo === undefined) {
+			return "unpublished"
+		} else {
+			return "published"
+		}
+	} catch (error) {
+		throw new Error(
+			`Failed to fetch package info for package ${pkg.name}: ${(error as Error).message}`
+		)
+	}
+}
+
+interface Status {
+	status: NpmStatus
+	pkg: Package
+}
+
+type Tag = "latest"
+
+function getTagFromPackage(_pkg: Package): Tag {
+	//TODO: once we use more than one tag, get the tag from the name properly
+	const tag = "latest"
+
+	return tag
+}
+
+async function processPackage(
+	pkg: Package,
+	token: string,
+	registry: string,
+	timeoutSec: number
+): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		setTimeout(() => {
+			reject(
+				new Error(
+					`Failed to publish for package ${pkg.name}: timeout (${timeoutSec} secs)`
+				)
+			)
+		}, timeoutSec * 1000)
+
+		const tag = getTagFromPackage(pkg)
+
+		const proc = child_process.spawn(
+			"npm",
+			[
+				"publish",
+				"--tag",
+				tag,
+				"--access",
+				"public",
+				"--provenance",
+				"--registry",
+				registry,
+			],
+			{
+				cwd: pkg.rootFolder,
+				env: { NPM_TOKEN: token },
+				shell: true,
+				stdio: "pipe",
+			}
+		)
+
+		let stderr = ""
+
+		proc.stderr.on("data", (data) => {
+			stderr += data.toString()
+		})
+
+		proc.on("error", (err) => {
+			reject(
+				new Error(
+					`Failed to publish for package ${pkg.name}: ${err.message}`
+				)
+			)
+			return
+		})
+
+		proc.on("exit", (code, signal) => {
+			if (signal !== null) {
+				console.error(stderr)
+				reject(
+					new Error(
+						`Failed to publish for package ${pkg.name}: caught signal ${signal}`
+					)
+				)
+				return
+			}
+
+			if (code !== 0) {
+				console.error(stderr)
+				reject(
+					new Error(
+						`Failed to publish for package ${pkg.name}: process exited with status code ${code}`
+					)
+				)
+				return
+			}
+
+			resolve()
+			return
+		})
+	})
+}
+
+async function collectPackages(): Promise<Package[]> {
+	const cwd = process.cwd()
+
+	const currentDir = __dirname
+
+	const expectedPackagePath = path.join(cwd, ".github", "release-script")
+
+	let packagePath = path.resolve(currentDir)
+
+	while (!fs.existsSync(path.join(packagePath, "package.json"))) {
+		packagePath = path.join(packagePath, "..")
+		if (packagePath === "" || packagePath === "/") {
+			throw new Error(
+				`Couldn't find package path by searching for package.json`
+			)
+		}
+	}
+
+	if (packagePath !== expectedPackagePath) {
+		throw new Error(
+			`Script executed from wrong cwd: expected package path to be '${expectedPackagePath}' but it was '${packagePath}'`
+		)
+	}
+
+	const allPackageFiles: string[] = await getAllFilesMatching(
+		process.cwd(),
+		(file: string) => {
+			if (path.dirname(file).includes(".github/release-script")) {
+				return false
+			}
+
+			return path.basename(file) === "package.json"
+		}
+	)
+
+	const packages: Package[] = await Promise.all(
+		allPackageFiles.map((packageFile) => getPackage(packageFile))
+	)
+	return packages
+}
+
+function isValidRegistry(_registry: string): boolean {
+	//TODO: implement, if necessary
+	return true
+}
+
+interface Options {
+	token: string
+	registry: string
+	timeoutSec: number
+}
+
+function getOptions(): Options {
+	const token = process.env["NPM_TOKEN"]
+
+	if (token === undefined || token === "") {
+		throw new Error(`env variable NPM_TOKEN not specified`)
+	}
+
+	let registry = "https://registry.npmjs.org/"
+
+	if (process.env["NPM_REGISTRY"] !== undefined) {
+		registry = process.env["NPM_REGISTRY"]
+	}
+
+	if (!isValidRegistry(registry)) {
+		throw new Error(`Invalid registry: ${registry}`)
+	}
+
+	let timeoutSec: number = 60
+
+	if (process.env["NPM_TIMEOUT_SEC"] !== undefined) {
+		const timeoutRaw = process.env["NPM_TIMEOUT_SEC"]
+		const timeoutNum = Number.parseInt(timeoutRaw)
+
+		if (Number.isNaN(timeoutNum)) {
+			throw new Error(
+				`Specified invalid timeout secs, not a number: ${timeoutRaw}`
+			)
+		}
+
+		timeoutSec = timeoutNum
+	}
+
+	return { registry: getNormalizedRegistryUrl(registry), timeoutSec, token }
+}
+
+async function main(): Promise<void> {
+	const { registry, timeoutSec, token } = getOptions()
+
+	const packages: Package[] = await collectPackages()
+
+	const npmStatus: Status[] = await Promise.all(
+		packages.map(async (pkg) => {
+			const status = await getNpmStatus(pkg, registry)
+
+			return { status, pkg }
+		})
+	)
+
+	await Promise.all(
+		npmStatus.map(async (status): Promise<void> => {
+			if (status.status === "unpublished") {
+				await processPackage(status.pkg, token, registry, timeoutSec)
+			}
+		})
+	)
+}
+
+void main()

--- a/.github/release-script/tsconfig.json
+++ b/.github/release-script/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "strict": true,
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release CI
+
+on:
+  release:
+    types: published
+  push:
+    branches:
+      - "main"
+
+env:
+  node-version: 22.x
+
+jobs:
+  release:
+    name: Release CI
+    runs-on: ubuntu-24.04
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # This also setups a .npmrc file to publish to npm
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Build Script
+        run: |
+          cd ./.github/release-script
+          npm ci
+          npm run build
+
+
+      - name: Publish 
+        run: node ./.github/release-script/
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,7 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
 
-      - name: Build Script
-        run: |
-          cd ./.github/release-script
-          npm ci
-          npm run build
-
-
       - name: Publish 
-        run: node ./.github/release-script/
+        run: node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings ./.github/release-script/src/index.ts
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Similar to https://github.com/gjsify/gnome-shell/pull/64

@JumpLink already knows what to setup and how provenance works.

So a few details on how this PR solves this.

You don't make releases here on GH, as you publish many packages in one commit and making a release for everyone here is not needed, as the releases (versions) are made on npm.

So this executes a GH action on every push to main, it executes this in the environment (npm-release)

It than builds and executes the script in `.github/release-script`.

That script does these things:
- it searches all `package,.json` files (except the one for that script) 
- it  extracts the data (name and version) from the package files for each package file
- it checks npm, if the version of the `package.json`  is already published
- if it is, it does nothing for this package
- if it isn't published yet, it uses `npm publish ... --provenance` to publish the package with that version to npm with provenance


It needs access to the NPM_TOKEN, like in https://github.com/gjsify/gnome-shell/pull/64 

As provenance is now standardized and npm + GH make it available, it would make sense, to publish all packages with provenance.

I tested this script with my own private repo (without provenance) and it works, as we use raw npm here and not yarn as in https://github.com/gjsify/gnome-shell/pull/64 there is no need for an additional fix like in https://github.com/gjsify/gnome-shell/pull/71

Feel free to ask any questions regarding the script 😄 

(It would also make sense, to test it on the next release of these types with only one package at a time, but we would need to hardcode something for that)
