### PR TITLE
fix: drop deprecated baseUrl from tsconfig.json

### DIFF
--- a/abi-3.0/tsconfig.json
+++ b/abi-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/accounts-1.0/tsconfig.json
+++ b/accounts-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/accountsservice-1.0/tsconfig.json
+++ b/accountsservice-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/adw-1/tsconfig.json
+++ b/adw-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ags-6.0/tsconfig.json
+++ b/ags-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ags-8.0/tsconfig.json
+++ b/ags-8.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/agsaudio-6.0/tsconfig.json
+++ b/agsaudio-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/agsaudio-8.0/tsconfig.json
+++ b/agsaudio-8.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/agsgui-6.0/tsconfig.json
+++ b/agsgui-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/agsgui-8.0/tsconfig.json
+++ b/agsgui-8.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/amtk-4/tsconfig.json
+++ b/amtk-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/amtk-5/tsconfig.json
+++ b/amtk-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/anacondawidgets-3.4/tsconfig.json
+++ b/anacondawidgets-3.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/anjuta-3.0/tsconfig.json
+++ b/anjuta-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/anthy-9000/tsconfig.json
+++ b/anthy-9000/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/appindicator3-0.1/tsconfig.json
+++ b/appindicator3-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/appstream-1.0/tsconfig.json
+++ b/appstream-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/appstreambuilder-1.0/tsconfig.json
+++ b/appstreambuilder-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/appstreamcompose-1.0/tsconfig.json
+++ b/appstreamcompose-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/appstreamglib-1.0/tsconfig.json
+++ b/appstreamglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrow-1.0/tsconfig.json
+++ b/arrow-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrow-23.0/tsconfig.json
+++ b/arrow-23.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrowcuda-1.0/tsconfig.json
+++ b/arrowcuda-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrowdataset-1.0/tsconfig.json
+++ b/arrowdataset-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrowdataset-23.0/tsconfig.json
+++ b/arrowdataset-23.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrowflight-1.0/tsconfig.json
+++ b/arrowflight-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/arrowflight-23.0/tsconfig.json
+++ b/arrowflight-23.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/atk-1.0/tsconfig.json
+++ b/atk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/atrildocument-1.5.0/tsconfig.json
+++ b/atrildocument-1.5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/atrilview-1.5.0/tsconfig.json
+++ b/atrilview-1.5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/atspi-2.0/tsconfig.json
+++ b/atspi-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/avahi-0.6/tsconfig.json
+++ b/avahi-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/avahicore-0.6/tsconfig.json
+++ b/avahicore-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ayatanaappindicator-0.1/tsconfig.json
+++ b/ayatanaappindicator-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ayatanaappindicator3-0.1/tsconfig.json
+++ b/ayatanaappindicator3-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ayatanaido3-0.4/tsconfig.json
+++ b/ayatanaido3-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/babl-0.1/tsconfig.json
+++ b/babl-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/bamf-3/tsconfig.json
+++ b/bamf-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/blockdev-3.0/tsconfig.json
+++ b/blockdev-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/braseroburn-3.1/tsconfig.json
+++ b/braseroburn-3.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/braseromedia-3.1/tsconfig.json
+++ b/braseromedia-3.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/budgie-1.0/tsconfig.json
+++ b/budgie-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/budgie-3.0/tsconfig.json
+++ b/budgie-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/budgieraven-1.0/tsconfig.json
+++ b/budgieraven-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/budgieraven-3.0/tsconfig.json
+++ b/budgieraven-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/builder-1.0/tsconfig.json
+++ b/builder-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/bump-0.1/tsconfig.json
+++ b/bump-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cairo-1.0/tsconfig.json
+++ b/cairo-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/caja-2.0/tsconfig.json
+++ b/caja-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-1.0/tsconfig.json
+++ b/cally-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-10/tsconfig.json
+++ b/cally-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-11/tsconfig.json
+++ b/cally-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-12/tsconfig.json
+++ b/cally-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-13/tsconfig.json
+++ b/cally-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-14/tsconfig.json
+++ b/cally-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-15/tsconfig.json
+++ b/cally-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-3/tsconfig.json
+++ b/cally-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-4/tsconfig.json
+++ b/cally-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-5/tsconfig.json
+++ b/cally-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-6/tsconfig.json
+++ b/cally-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-7/tsconfig.json
+++ b/cally-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-8/tsconfig.json
+++ b/cally-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cally-9/tsconfig.json
+++ b/cally-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cambalacheprivate-3.0/tsconfig.json
+++ b/cambalacheprivate-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cambalacheprivate-4.0/tsconfig.json
+++ b/cambalacheprivate-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/camel-1.2/tsconfig.json
+++ b/camel-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/caribou-1.0/tsconfig.json
+++ b/caribou-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/casilda-0.1/tsconfig.json
+++ b/casilda-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/casilda-1.0/tsconfig.json
+++ b/casilda-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cdesktopenums-3.0/tsconfig.json
+++ b/cdesktopenums-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/champlain-0.12/tsconfig.json
+++ b/champlain-0.12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cheese-3.0/tsconfig.json
+++ b/cheese-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cinnamondesktop-3.0/tsconfig.json
+++ b/cinnamondesktop-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clapper-0.0/tsconfig.json
+++ b/clapper-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clappergtk-0.0/tsconfig.json
+++ b/clappergtk-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cloudproviders-0.3/tsconfig.json
+++ b/cloudproviders-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-1.0/tsconfig.json
+++ b/clutter-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-10/tsconfig.json
+++ b/clutter-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-11/tsconfig.json
+++ b/clutter-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-12/tsconfig.json
+++ b/clutter-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-13/tsconfig.json
+++ b/clutter-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-14/tsconfig.json
+++ b/clutter-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-15/tsconfig.json
+++ b/clutter-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-16/tsconfig.json
+++ b/clutter-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-17/tsconfig.json
+++ b/clutter-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-18/tsconfig.json
+++ b/clutter-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-3/tsconfig.json
+++ b/clutter-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-4/tsconfig.json
+++ b/clutter-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-5/tsconfig.json
+++ b/clutter-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-6/tsconfig.json
+++ b/clutter-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-7/tsconfig.json
+++ b/clutter-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-8/tsconfig.json
+++ b/clutter-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutter-9/tsconfig.json
+++ b/clutter-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cluttergdk-1.0/tsconfig.json
+++ b/cluttergdk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cluttergst-2.0/tsconfig.json
+++ b/cluttergst-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cluttergst-3.0/tsconfig.json
+++ b/cluttergst-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-1.0/tsconfig.json
+++ b/clutterx11-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-3/tsconfig.json
+++ b/clutterx11-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-4/tsconfig.json
+++ b/clutterx11-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-5/tsconfig.json
+++ b/clutterx11-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-6/tsconfig.json
+++ b/clutterx11-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-7/tsconfig.json
+++ b/clutterx11-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/clutterx11-8/tsconfig.json
+++ b/clutterx11-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cmbcatalogutils-3.0/tsconfig.json
+++ b/cmbcatalogutils-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cmbcatalogutils-4.0/tsconfig.json
+++ b/cmbcatalogutils-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cmenu-3.0/tsconfig.json
+++ b/cmenu-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-1.0/tsconfig.json
+++ b/cogl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-10/tsconfig.json
+++ b/cogl-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-11/tsconfig.json
+++ b/cogl-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-12/tsconfig.json
+++ b/cogl-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-13/tsconfig.json
+++ b/cogl-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-14/tsconfig.json
+++ b/cogl-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-15/tsconfig.json
+++ b/cogl-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-16/tsconfig.json
+++ b/cogl-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-17/tsconfig.json
+++ b/cogl-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-18/tsconfig.json
+++ b/cogl-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-2.0/tsconfig.json
+++ b/cogl-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-3/tsconfig.json
+++ b/cogl-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-4/tsconfig.json
+++ b/cogl-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-5/tsconfig.json
+++ b/cogl-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-6/tsconfig.json
+++ b/cogl-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-7/tsconfig.json
+++ b/cogl-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-8/tsconfig.json
+++ b/cogl-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cogl-9/tsconfig.json
+++ b/cogl-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglgst-2.0/tsconfig.json
+++ b/coglgst-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-1.0/tsconfig.json
+++ b/coglpango-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-10/tsconfig.json
+++ b/coglpango-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-11/tsconfig.json
+++ b/coglpango-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-12/tsconfig.json
+++ b/coglpango-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-13/tsconfig.json
+++ b/coglpango-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-14/tsconfig.json
+++ b/coglpango-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-15/tsconfig.json
+++ b/coglpango-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-2.0/tsconfig.json
+++ b/coglpango-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-3/tsconfig.json
+++ b/coglpango-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-4/tsconfig.json
+++ b/coglpango-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-5/tsconfig.json
+++ b/coglpango-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-6/tsconfig.json
+++ b/coglpango-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-7/tsconfig.json
+++ b/coglpango-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-8/tsconfig.json
+++ b/coglpango-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/coglpango-9/tsconfig.json
+++ b/coglpango-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/colord-1.0/tsconfig.json
+++ b/colord-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/colordgtk-1.0/tsconfig.json
+++ b/colordgtk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/colorhug-1.0/tsconfig.json
+++ b/colorhug-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cryptui-0.0/tsconfig.json
+++ b/cryptui-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cudagst-1.0/tsconfig.json
+++ b/cudagst-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/cvc-1.0/tsconfig.json
+++ b/cvc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dazzle-1.0/tsconfig.json
+++ b/dazzle-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dbus-1.0/tsconfig.json
+++ b/dbus-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dbusglib-1.0/tsconfig.json
+++ b/dbusglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dbusmenu-0.4/tsconfig.json
+++ b/dbusmenu-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dbusmenugtk-0.4/tsconfig.json
+++ b/dbusmenugtk-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dbusmenugtk3-0.4/tsconfig.json
+++ b/dbusmenugtk3-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dee-1.0/tsconfig.json
+++ b/dee-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/devhelp-3.0/tsconfig.json
+++ b/devhelp-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/deviced-1.0/tsconfig.json
+++ b/deviced-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dex-1/tsconfig.json
+++ b/dex-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dmap-3.0/tsconfig.json
+++ b/dmap-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/dmap-4.0/tsconfig.json
+++ b/dmap-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/easyfc-0.14/tsconfig.json
+++ b/easyfc-0.14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ebackend-1.2/tsconfig.json
+++ b/ebackend-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ebook-1.2/tsconfig.json
+++ b/ebook-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ebookcontacts-1.2/tsconfig.json
+++ b/ebookcontacts-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ecal-2.0/tsconfig.json
+++ b/ecal-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ecalendar-1.2/tsconfig.json
+++ b/ecalendar-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/edatabook-1.2/tsconfig.json
+++ b/edatabook-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/edatacal-2.0/tsconfig.json
+++ b/edatacal-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/edataserver-1.2/tsconfig.json
+++ b/edataserver-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/edataserverui-1.2/tsconfig.json
+++ b/edataserverui-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/edataserverui4-1.0/tsconfig.json
+++ b/edataserverui4-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/egg-1.0/tsconfig.json
+++ b/egg-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/entangle-0.1/tsconfig.json
+++ b/entangle-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/eog-3.0/tsconfig.json
+++ b/eog-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/eom-1.0/tsconfig.json
+++ b/eom-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/epc-1.0/tsconfig.json
+++ b/epc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/epcui-1.0/tsconfig.json
+++ b/epcui-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/evincedocument-3.0/tsconfig.json
+++ b/evincedocument-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/evinceview-3.0/tsconfig.json
+++ b/evinceview-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/farstream-0.1/tsconfig.json
+++ b/farstream-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/farstream-0.2/tsconfig.json
+++ b/farstream-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fcitx-1.0/tsconfig.json
+++ b/fcitx-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fcitxg-1.0/tsconfig.json
+++ b/fcitxg-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fep-1.0/tsconfig.json
+++ b/fep-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/flatpak-1.0/tsconfig.json
+++ b/flatpak-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folks-0.6/tsconfig.json
+++ b/folks-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folks-0.7/tsconfig.json
+++ b/folks-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folksdummy-0.6/tsconfig.json
+++ b/folksdummy-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folksdummy-0.7/tsconfig.json
+++ b/folksdummy-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folkseds-0.6/tsconfig.json
+++ b/folkseds-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folkseds-0.7/tsconfig.json
+++ b/folkseds-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folkslibsocialweb-0.6/tsconfig.json
+++ b/folkslibsocialweb-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folkstelepathy-0.6/tsconfig.json
+++ b/folkstelepathy-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/folkstelepathy-0.7/tsconfig.json
+++ b/folkstelepathy-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fontconfig-2.0/tsconfig.json
+++ b/fontconfig-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/foundry-1/tsconfig.json
+++ b/foundry-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/foundryadw-1/tsconfig.json
+++ b/foundryadw-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/foundrygtk-1/tsconfig.json
+++ b/foundrygtk-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fprint-2.0/tsconfig.json
+++ b/fprint-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/freetype2-2.0/tsconfig.json
+++ b/freetype2-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/fwupd-2.0/tsconfig.json
+++ b/fwupd-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gamerzilla-0.1/tsconfig.json
+++ b/gamerzilla-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gandiva-1.0/tsconfig.json
+++ b/gandiva-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/garcon-1.0/tsconfig.json
+++ b/garcon-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/garcongtk-1.0/tsconfig.json
+++ b/garcongtk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gc-1.0/tsconfig.json
+++ b/gc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcab-1.0/tsconfig.json
+++ b/gcab-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcalc-1/tsconfig.json
+++ b/gcalc-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcalc-2/tsconfig.json
+++ b/gcalc-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gci-1/tsconfig.json
+++ b/gci-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gck-1/tsconfig.json
+++ b/gck-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gck-2/tsconfig.json
+++ b/gck-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gconf-2.0/tsconfig.json
+++ b/gconf-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcr-3/tsconfig.json
+++ b/gcr-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcr-4/tsconfig.json
+++ b/gcr-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcrgtk3-4/tsconfig.json
+++ b/gcrgtk3-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcrgtk4-4/tsconfig.json
+++ b/gcrgtk4-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gcrui-3/tsconfig.json
+++ b/gcrui-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gd-1.0/tsconfig.json
+++ b/gd-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gda-5.0/tsconfig.json
+++ b/gda-5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gda-6.0/tsconfig.json
+++ b/gda-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdata-0.0/tsconfig.json
+++ b/gdata-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdaui-5.0/tsconfig.json
+++ b/gdaui-5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdaui-6.0/tsconfig.json
+++ b/gdaui-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdesktopenums-3.0/tsconfig.json
+++ b/gdesktopenums-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdk-2.0/tsconfig.json
+++ b/gdk-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdk-3.0/tsconfig.json
+++ b/gdk-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdk-4.0/tsconfig.json
+++ b/gdk-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkmacos-4.0/tsconfig.json
+++ b/gdkmacos-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkpixbuf-2.0/tsconfig.json
+++ b/gdkpixbuf-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkpixdata-2.0/tsconfig.json
+++ b/gdkpixdata-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkwayland-4.0/tsconfig.json
+++ b/gdkwayland-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkwin32-4.0/tsconfig.json
+++ b/gdkwin32-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkx11-2.0/tsconfig.json
+++ b/gdkx11-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkx11-3.0/tsconfig.json
+++ b/gdkx11-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdkx11-4.0/tsconfig.json
+++ b/gdkx11-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdl-3/tsconfig.json
+++ b/gdl-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gdm-1.0/tsconfig.json
+++ b/gdm-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gedit-3.0/tsconfig.json
+++ b/gedit-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gee-0.8/tsconfig.json
+++ b/gee-0.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gee-1.0/tsconfig.json
+++ b/gee-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gegl-0.3/tsconfig.json
+++ b/gegl-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gegl-0.4/tsconfig.json
+++ b/gegl-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/geglgtk3-0.1/tsconfig.json
+++ b/geglgtk3-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/geoclue-2.0/tsconfig.json
+++ b/geoclue-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/geocodeglib-1.0/tsconfig.json
+++ b/geocodeglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/geocodeglib-2.0/tsconfig.json
+++ b/geocodeglib-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gepub-0.5/tsconfig.json
+++ b/gepub-0.5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gepub-0.7/tsconfig.json
+++ b/gepub-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ges-1.0/tsconfig.json
+++ b/ges-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gexiv2-0.10/tsconfig.json
+++ b/gexiv2-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gexiv2-0.16/tsconfig.json
+++ b/gexiv2-0.16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gfbgraph-0.2/tsconfig.json
+++ b/gfbgraph-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gfbgraph-0.3/tsconfig.json
+++ b/gfbgraph-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gfls-1/tsconfig.json
+++ b/gfls-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ggit-1.0/tsconfig.json
+++ b/ggit-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gimp-3.0/tsconfig.json
+++ b/gimp-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gimpui-3.0/tsconfig.json
+++ b/gimpui-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gio-2.0/tsconfig.json
+++ b/gio-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/giounix-2.0/tsconfig.json
+++ b/giounix-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/giowin32-2.0/tsconfig.json
+++ b/giowin32-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/girepository-2.0/tsconfig.json
+++ b/girepository-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/girepository-3.0/tsconfig.json
+++ b/girepository-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gitg-1.0/tsconfig.json
+++ b/gitg-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gitgext-1.0/tsconfig.json
+++ b/gitgext-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gjs/tsconfig.json
+++ b/gjs/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gjsdbus-1.0/tsconfig.json
+++ b/gjsdbus-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gjsprivate-1.0/tsconfig.json
+++ b/gjsprivate-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gkbd-3.0/tsconfig.json
+++ b/gkbd-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gl-1.0/tsconfig.json
+++ b/gl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gladeui-2.0/tsconfig.json
+++ b/gladeui-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/glib-2.0/tsconfig.json
+++ b/glib-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/glibunix-2.0/tsconfig.json
+++ b/glibunix-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/glibwin32-2.0/tsconfig.json
+++ b/glibwin32-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gly-1/tsconfig.json
+++ b/gly-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gly-2/tsconfig.json
+++ b/gly-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/glygtk4-1/tsconfig.json
+++ b/glygtk4-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/glygtk4-2/tsconfig.json
+++ b/glygtk4-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gm-0/tsconfig.json
+++ b/gm-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gmenu-3.0/tsconfig.json
+++ b/gmenu-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gmime-2.6/tsconfig.json
+++ b/gmime-2.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gmime-3.0/tsconfig.json
+++ b/gmime-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gmodule-2.0/tsconfig.json
+++ b/gmodule-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomeautoar-0.1/tsconfig.json
+++ b/gnomeautoar-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomeautoargtk-0.1/tsconfig.json
+++ b/gnomeautoargtk-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomebg-4.0/tsconfig.json
+++ b/gnomebg-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomebluetooth-1.0/tsconfig.json
+++ b/gnomebluetooth-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomebluetooth-3.0/tsconfig.json
+++ b/gnomebluetooth-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomedesktop-3.0/tsconfig.json
+++ b/gnomedesktop-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomedesktop-4.0/tsconfig.json
+++ b/gnomedesktop-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomekeyring-1.0/tsconfig.json
+++ b/gnomekeyring-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomemaps-1.0/tsconfig.json
+++ b/gnomemaps-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gnomerr-4.0/tsconfig.json
+++ b/gnomerr-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/goa-1.0/tsconfig.json
+++ b/goa-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gobject-2.0/tsconfig.json
+++ b/gobject-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gom-1.0/tsconfig.json
+++ b/gom-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/goocanvas-2.0/tsconfig.json
+++ b/goocanvas-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/goocanvas-3.0/tsconfig.json
+++ b/goocanvas-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/govf-0.1/tsconfig.json
+++ b/govf-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/govirt-1.0/tsconfig.json
+++ b/govirt-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gpaste-2/tsconfig.json
+++ b/gpaste-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gpastegtk-3/tsconfig.json
+++ b/gpastegtk-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gpastegtk-4/tsconfig.json
+++ b/gpastegtk-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gpiodglib-1.0/tsconfig.json
+++ b/gpiodglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gplugin-1.0/tsconfig.json
+++ b/gplugin-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gplugingtk4-1.0/tsconfig.json
+++ b/gplugingtk4-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gpseq-1.0/tsconfig.json
+++ b/gpseq-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/granite-1.0/granite-1.0.d.ts
+++ b/granite-1.0/granite-1.0.d.ts
@@ -30,7 +30,7 @@ export namespace Granite {
 
 // Workaround
 /** @ignore */
-export module GraniteServicesSettingsSerializable {
+export namespace GraniteServicesSettingsSerializable {
     export interface ConstructorProps extends ServicesSettingsSerializable.ConstructorProps {}
 }
 /** @ignore */

--- a/granite-1.0/tsconfig.json
+++ b/granite-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/granite-7.0/granite-7.0.d.ts
+++ b/granite-7.0/granite-7.0.d.ts
@@ -31,7 +31,7 @@ export namespace Granite {
 
 // Workaround
 /** @ignore */
-export module GraniteServicesSettingsSerializable {
+export namespace GraniteServicesSettingsSerializable {
     export interface ConstructorProps extends ServicesSettingsSerializable.ConstructorProps {}
 }
 /** @ignore */

--- a/granite-7.0/tsconfig.json
+++ b/granite-7.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/graphene-1.0/tsconfig.json
+++ b/graphene-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grl-0.1/tsconfig.json
+++ b/grl-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grl-0.2/tsconfig.json
+++ b/grl-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grl-0.3/tsconfig.json
+++ b/grl-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grlnet-0.1/tsconfig.json
+++ b/grlnet-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grlnet-0.2/tsconfig.json
+++ b/grlnet-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grlnet-0.3/tsconfig.json
+++ b/grlnet-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grlpls-0.2/tsconfig.json
+++ b/grlpls-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grlpls-0.3/tsconfig.json
+++ b/grlpls-0.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/grss-0.7/tsconfig.json
+++ b/grss-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsf-1/tsconfig.json
+++ b/gsf-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsignon-1.0/tsconfig.json
+++ b/gsignon-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsignond-1.0/tsconfig.json
+++ b/gsignond-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsk-4.0/tsconfig.json
+++ b/gsk-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsound-1.0/tsconfig.json
+++ b/gsound-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gspell-1/tsconfig.json
+++ b/gspell-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gssdp-1.0/tsconfig.json
+++ b/gssdp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gssdp-1.2/tsconfig.json
+++ b/gssdp-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gssdp-1.6/tsconfig.json
+++ b/gssdp-1.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gst-0.10/tsconfig.json
+++ b/gst-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gst-1.0/tsconfig.json
+++ b/gst-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstallocators-1.0/tsconfig.json
+++ b/gstallocators-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstanalytics-1.0/tsconfig.json
+++ b/gstanalytics-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstapp-1.0/tsconfig.json
+++ b/gstapp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstaudio-1.0/tsconfig.json
+++ b/gstaudio-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstbadallocators-1.0/tsconfig.json
+++ b/gstbadallocators-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstbadaudio-1.0/tsconfig.json
+++ b/gstbadaudio-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstbase-0.10/gstbase-0.10.d.ts
+++ b/gstbase-0.10/gstbase-0.10.d.ts
@@ -21,7 +21,7 @@ export namespace GstBase {
 
 // Workaround
 /** @ignore */
-export module BaseSink {
+export namespace BaseSink {
     export type ConstructorProps = Gst.BaseSink.ConstructorProps;
 }
 

--- a/gstbase-0.10/tsconfig.json
+++ b/gstbase-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstbase-1.0/tsconfig.json
+++ b/gstbase-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstcheck-1.0/tsconfig.json
+++ b/gstcheck-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstclapper-1.0/tsconfig.json
+++ b/gstclapper-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstcodecparsers-1.0/tsconfig.json
+++ b/gstcodecparsers-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstcodecs-1.0/tsconfig.json
+++ b/gstcodecs-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstcontroller-1.0/tsconfig.json
+++ b/gstcontroller-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstcuda-1.0/tsconfig.json
+++ b/gstcuda-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstdxva-1.0/tsconfig.json
+++ b/gstdxva-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstfft-1.0/tsconfig.json
+++ b/gstfft-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstgl-1.0/tsconfig.json
+++ b/gstgl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstglegl-1.0/tsconfig.json
+++ b/gstglegl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstglwayland-1.0/tsconfig.json
+++ b/gstglwayland-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstglx11-1.0/tsconfig.json
+++ b/gstglx11-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsthip-1.0/tsconfig.json
+++ b/gsthip-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsthipgl-1.0/tsconfig.json
+++ b/gsthipgl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstinsertbin-1.0/tsconfig.json
+++ b/gstinsertbin-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstinterfaces-0.10/tsconfig.json
+++ b/gstinterfaces-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstmpegts-1.0/tsconfig.json
+++ b/gstmpegts-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstmse-1.0/tsconfig.json
+++ b/gstmse-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstnet-1.0/tsconfig.json
+++ b/gstnet-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstpbutils-0.10/tsconfig.json
+++ b/gstpbutils-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstpbutils-1.0/tsconfig.json
+++ b/gstpbutils-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstplay-1.0/tsconfig.json
+++ b/gstplay-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstplayer-1.0/tsconfig.json
+++ b/gstplayer-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstriff-1.0/tsconfig.json
+++ b/gstriff-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstrtp-1.0/tsconfig.json
+++ b/gstrtp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstrtsp-1.0/tsconfig.json
+++ b/gstrtsp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstrtspserver-1.0/tsconfig.json
+++ b/gstrtspserver-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstsdp-1.0/tsconfig.json
+++ b/gstsdp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsttag-0.10/tsconfig.json
+++ b/gsttag-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsttag-1.0/tsconfig.json
+++ b/gsttag-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsttranscoder-1.0/tsconfig.json
+++ b/gsttranscoder-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstva-1.0/tsconfig.json
+++ b/gstva-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvalidate-1.0/tsconfig.json
+++ b/gstvalidate-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvideo-0.10/tsconfig.json
+++ b/gstvideo-0.10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvideo-1.0/tsconfig.json
+++ b/gstvideo-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvulkan-1.0/tsconfig.json
+++ b/gstvulkan-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvulkanwayland-1.0/tsconfig.json
+++ b/gstvulkanwayland-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstvulkanxcb-1.0/tsconfig.json
+++ b/gstvulkanxcb-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gstwebrtc-1.0/tsconfig.json
+++ b/gstwebrtc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gsystem-1.0/tsconfig.json
+++ b/gsystem-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtd-1.0/tsconfig.json
+++ b/gtd-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtef-2/tsconfig.json
+++ b/gtef-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gthree-1.0/tsconfig.json
+++ b/gthree-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gthreegtk3-1.0/tsconfig.json
+++ b/gthreegtk3-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtk-2.0/tsconfig.json
+++ b/gtk-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtk-3.0/tsconfig.json
+++ b/gtk-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtk-4.0/tsconfig.json
+++ b/gtk-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtk4layershell-1.0/tsconfig.json
+++ b/gtk4layershell-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtk4sessionlock-1.0/tsconfig.json
+++ b/gtk4sessionlock-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkchamplain-0.12/tsconfig.json
+++ b/gtkchamplain-0.12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkclutter-1.0/tsconfig.json
+++ b/gtkclutter-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkfrdp-0.2/tsconfig.json
+++ b/gtkfrdp-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtklayershell-0.1/tsconfig.json
+++ b/gtklayershell-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkosxapplication-1.0/tsconfig.json
+++ b/gtkosxapplication-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksessionlock-0.1/tsconfig.json
+++ b/gtksessionlock-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksource-2.0/tsconfig.json
+++ b/gtksource-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksource-3.0/tsconfig.json
+++ b/gtksource-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksource-300/tsconfig.json
+++ b/gtksource-300/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksource-4/tsconfig.json
+++ b/gtksource-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtksource-5/tsconfig.json
+++ b/gtksource-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkspell-3.0/tsconfig.json
+++ b/gtkspell-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtkvnc-2.0/tsconfig.json
+++ b/gtkvnc-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gtop-2.0/tsconfig.json
+++ b/gtop-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gucharmap-2.90/tsconfig.json
+++ b/gucharmap-2.90/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gudev-1.0/tsconfig.json
+++ b/gudev-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/guestfs-1.0/tsconfig.json
+++ b/guestfs-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnp-1.0/tsconfig.json
+++ b/gupnp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnp-1.2/tsconfig.json
+++ b/gupnp-1.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnp-1.6/tsconfig.json
+++ b/gupnp-1.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpav-1.0/tsconfig.json
+++ b/gupnpav-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpdlna-1.0/tsconfig.json
+++ b/gupnpdlna-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpdlna-2.0/tsconfig.json
+++ b/gupnpdlna-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpdlnagst-2.0/tsconfig.json
+++ b/gupnpdlnagst-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpigd-1.0/tsconfig.json
+++ b/gupnpigd-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gupnpigd-1.6/tsconfig.json
+++ b/gupnpigd-1.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gusb-1.0/tsconfig.json
+++ b/gusb-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gvc-1.0/tsconfig.json
+++ b/gvc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gvnc-1.0/tsconfig.json
+++ b/gvnc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gvncpulse-1.0/tsconfig.json
+++ b/gvncpulse-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gweather-3.0/tsconfig.json
+++ b/gweather-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gweather-4.0/tsconfig.json
+++ b/gweather-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxml-0.14/tsconfig.json
+++ b/gxml-0.14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxml-0.16/tsconfig.json
+++ b/gxml-0.16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxml-0.18/tsconfig.json
+++ b/gxml-0.18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxml-0.20/tsconfig.json
+++ b/gxml-0.20/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxps-0.1/tsconfig.json
+++ b/gxps-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/gxps-1.0/tsconfig.json
+++ b/gxps-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/handy-0.0/tsconfig.json
+++ b/handy-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/handy-1/tsconfig.json
+++ b/handy-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/harfbuzz-0.0/tsconfig.json
+++ b/harfbuzz-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/hex-4/tsconfig.json
+++ b/hex-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/hs-1/tsconfig.json
+++ b/hs-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ianjuta-3.0/tsconfig.json
+++ b/ianjuta-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ibus-1.0/tsconfig.json
+++ b/ibus-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ical-3.0/tsconfig.json
+++ b/ical-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/icalglib-3.0/tsconfig.json
+++ b/icalglib-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-1.0/tsconfig.json
+++ b/ide-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-45/tsconfig.json
+++ b/ide-45/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-46/tsconfig.json
+++ b/ide-46/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-47/tsconfig.json
+++ b/ide-47/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-49/tsconfig.json
+++ b/ide-49/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ide-50/tsconfig.json
+++ b/ide-50/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/imsettings-1.8/tsconfig.json
+++ b/imsettings-1.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/inputpad-1.1/tsconfig.json
+++ b/inputpad-1.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ipuz-1.0/tsconfig.json
+++ b/ipuz-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/javascriptcore-4.0/tsconfig.json
+++ b/javascriptcore-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/javascriptcore-4.1/tsconfig.json
+++ b/javascriptcore-4.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/javascriptcore-5.0/tsconfig.json
+++ b/javascriptcore-5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/javascriptcore-6.0/tsconfig.json
+++ b/javascriptcore-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/jcat-1.0/tsconfig.json
+++ b/jcat-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/jscore-3.0/tsconfig.json
+++ b/jscore-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/json-1.0/tsconfig.json
+++ b/json-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/jsonrpc-1.0/tsconfig.json
+++ b/jsonrpc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/keybinder-0.0/tsconfig.json
+++ b/keybinder-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/keybinder-3.0/tsconfig.json
+++ b/keybinder-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/kkc-1.0/tsconfig.json
+++ b/kkc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/langtag-0.6/tsconfig.json
+++ b/langtag-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/lasem-0.4/tsconfig.json
+++ b/lasem-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/lasem-0.6/tsconfig.json
+++ b/lasem-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/lfb-0.0/tsconfig.json
+++ b/lfb-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libinsane-1.0/tsconfig.json
+++ b/libinsane-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libmsi-1.0/tsconfig.json
+++ b/libmsi-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libosinfo-1.0/tsconfig.json
+++ b/libosinfo-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libproxy-1.0/tsconfig.json
+++ b/libproxy-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libsitra-0.1/tsconfig.json
+++ b/libsitra-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libvirtgconfig-1.0/tsconfig.json
+++ b/libvirtgconfig-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libvirtglib-1.0/tsconfig.json
+++ b/libvirtglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libvirtgobject-1.0/tsconfig.json
+++ b/libvirtgobject-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libvirtsandbox-1.0/tsconfig.json
+++ b/libvirtsandbox-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxfce4panel-2.0/tsconfig.json
+++ b/libxfce4panel-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxfce4ui-2.0/tsconfig.json
+++ b/libxfce4ui-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxfce4util-1.0/tsconfig.json
+++ b/libxfce4util-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxfce4windowing-0.0/tsconfig.json
+++ b/libxfce4windowing-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxfce4windowingui-0.0/tsconfig.json
+++ b/libxfce4windowingui-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/libxml2-2.0/tsconfig.json
+++ b/libxml2-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/liferea-3.0/tsconfig.json
+++ b/liferea-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/lightdm-1/tsconfig.json
+++ b/lightdm-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/malcontent-0/tsconfig.json
+++ b/malcontent-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/malcontentui-1/tsconfig.json
+++ b/malcontentui-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/manette-0.2/tsconfig.json
+++ b/manette-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/manette-1/tsconfig.json
+++ b/manette-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mash-0.2/tsconfig.json
+++ b/mash-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/matedesktop-2.0/tsconfig.json
+++ b/matedesktop-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/matekbd-1.0/tsconfig.json
+++ b/matekbd-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/matemenu-2.0/tsconfig.json
+++ b/matemenu-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/matepanelapplet-4.0/tsconfig.json
+++ b/matepanelapplet-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mbim-1.0/tsconfig.json
+++ b/mbim-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mediaart-1.0/tsconfig.json
+++ b/mediaart-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mediaart-2.0/tsconfig.json
+++ b/mediaart-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-10/tsconfig.json
+++ b/meta-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-11/tsconfig.json
+++ b/meta-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-12/tsconfig.json
+++ b/meta-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-13/tsconfig.json
+++ b/meta-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-14/tsconfig.json
+++ b/meta-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-15/tsconfig.json
+++ b/meta-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-16/tsconfig.json
+++ b/meta-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-17/tsconfig.json
+++ b/meta-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-18/tsconfig.json
+++ b/meta-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-3/tsconfig.json
+++ b/meta-3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-4/tsconfig.json
+++ b/meta-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-5/tsconfig.json
+++ b/meta-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-6/tsconfig.json
+++ b/meta-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-7/tsconfig.json
+++ b/meta-7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-8/tsconfig.json
+++ b/meta-8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/meta-9/tsconfig.json
+++ b/meta-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-12/tsconfig.json
+++ b/metatest-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-13/tsconfig.json
+++ b/metatest-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-14/tsconfig.json
+++ b/metatest-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-15/tsconfig.json
+++ b/metatest-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-16/tsconfig.json
+++ b/metatest-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-17/tsconfig.json
+++ b/metatest-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/metatest-18/tsconfig.json
+++ b/metatest-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/midori-0.6/tsconfig.json
+++ b/midori-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ministream-1/tsconfig.json
+++ b/ministream-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mirage-3.2/tsconfig.json
+++ b/mirage-3.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mks-1/tsconfig.json
+++ b/mks-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/modemmanager-1.0/tsconfig.json
+++ b/modemmanager-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/modulemd-2.0/tsconfig.json
+++ b/modulemd-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mpid-3.0/tsconfig.json
+++ b/mpid-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/msg-0/tsconfig.json
+++ b/msg-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/msg-1/tsconfig.json
+++ b/msg-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-13/tsconfig.json
+++ b/mtk-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-14/tsconfig.json
+++ b/mtk-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-15/tsconfig.json
+++ b/mtk-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-16/tsconfig.json
+++ b/mtk-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-17/tsconfig.json
+++ b/mtk-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mtk-18/tsconfig.json
+++ b/mtk-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mx-1.0/tsconfig.json
+++ b/mx-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mx-2.0/tsconfig.json
+++ b/mx-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mxgtk-1.0/tsconfig.json
+++ b/mxgtk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mypaint-1.6/tsconfig.json
+++ b/mypaint-1.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/mypaintgegl-1.6/tsconfig.json
+++ b/mypaintgegl-1.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nautilus-3.0/tsconfig.json
+++ b/nautilus-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nautilus-4.0/tsconfig.json
+++ b/nautilus-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nautilus-4.1/tsconfig.json
+++ b/nautilus-4.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nemo-3.0/tsconfig.json
+++ b/nemo-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nemopreview-1.0/tsconfig.json
+++ b/nemopreview-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/networkmanager-1.0/tsconfig.json
+++ b/networkmanager-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nice-0.1/tsconfig.json
+++ b/nice-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nm-1.0/tsconfig.json
+++ b/nm-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nma-1.0/tsconfig.json
+++ b/nma-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nma4-1.0/tsconfig.json
+++ b/nma4-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nmclient-1.0/tsconfig.json
+++ b/nmclient-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/nmgtk-1.0/tsconfig.json
+++ b/nmgtk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/notify-0.7/tsconfig.json
+++ b/notify-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/osmgpsmap-1.0/tsconfig.json
+++ b/osmgpsmap-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/ostree-1.0/tsconfig.json
+++ b/ostree-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/p11kit-1.0/tsconfig.json
+++ b/p11kit-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/packagekitglib-1.0/tsconfig.json
+++ b/packagekitglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/packagekitplugin-1.0/tsconfig.json
+++ b/packagekitplugin-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/panel-1/tsconfig.json
+++ b/panel-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/panelapplet-4.0/tsconfig.json
+++ b/panelapplet-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pango-1.0/tsconfig.json
+++ b/pango-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pangocairo-1.0/tsconfig.json
+++ b/pangocairo-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pangofc-1.0/tsconfig.json
+++ b/pangofc-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pangoft2-1.0/tsconfig.json
+++ b/pangoft2-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pangoot-1.0/tsconfig.json
+++ b/pangoot-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pangoxft-1.0/tsconfig.json
+++ b/pangoxft-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pantheonwayland-1/tsconfig.json
+++ b/pantheonwayland-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/parquet-1.0/tsconfig.json
+++ b/parquet-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/parquet-23.0/tsconfig.json
+++ b/parquet-23.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/passim-1.0/tsconfig.json
+++ b/passim-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/peas-1.0/tsconfig.json
+++ b/peas-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/peas-2/tsconfig.json
+++ b/peas-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/peasgtk-1.0/tsconfig.json
+++ b/peasgtk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/phosh-0/tsconfig.json
+++ b/phosh-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/plasma-1.0/tsconfig.json
+++ b/plasma-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/playerctl-2.0/tsconfig.json
+++ b/playerctl-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pluma-1.0/tsconfig.json
+++ b/pluma-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pnl-1.0/tsconfig.json
+++ b/pnl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/polkit-1.0/tsconfig.json
+++ b/polkit-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/polkitagent-1.0/tsconfig.json
+++ b/polkitagent-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/poppler-0.18/tsconfig.json
+++ b/poppler-0.18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/pqmarble-2/tsconfig.json
+++ b/pqmarble-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/qmi-1.0/tsconfig.json
+++ b/qmi-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/qrtr-1.0/tsconfig.json
+++ b/qrtr-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rb-3.0/tsconfig.json
+++ b/rb-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rest-0.7/tsconfig.json
+++ b/rest-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rest-1.0/tsconfig.json
+++ b/rest-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/restextras-0.7/tsconfig.json
+++ b/restextras-0.7/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/restextras-1.0/tsconfig.json
+++ b/restextras-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/retro-0.14/tsconfig.json
+++ b/retro-0.14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/retro-1/tsconfig.json
+++ b/retro-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/retro-2/tsconfig.json
+++ b/retro-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rpmostree-1.0/tsconfig.json
+++ b/rpmostree-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rsvg-2.0/tsconfig.json
+++ b/rsvg-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelcore-2.6/tsconfig.json
+++ b/rygelcore-2.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelcore-2.8/tsconfig.json
+++ b/rygelcore-2.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelrenderer-2.6/tsconfig.json
+++ b/rygelrenderer-2.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelrenderer-2.8/tsconfig.json
+++ b/rygelrenderer-2.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelrenderergst-2.6/tsconfig.json
+++ b/rygelrenderergst-2.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelrenderergst-2.8/tsconfig.json
+++ b/rygelrenderergst-2.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelserver-2.6/tsconfig.json
+++ b/rygelserver-2.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/rygelserver-2.8/tsconfig.json
+++ b/rygelserver-2.8/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/secret-1/tsconfig.json
+++ b/secret-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/secretunstable-0/tsconfig.json
+++ b/secretunstable-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-0.1/tsconfig.json
+++ b/shell-0.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-10/tsconfig.json
+++ b/shell-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-11/tsconfig.json
+++ b/shell-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-12/tsconfig.json
+++ b/shell-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-13/tsconfig.json
+++ b/shell-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-14/tsconfig.json
+++ b/shell-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-15/tsconfig.json
+++ b/shell-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-16/tsconfig.json
+++ b/shell-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-17/tsconfig.json
+++ b/shell-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-18/tsconfig.json
+++ b/shell-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shell-9/tsconfig.json
+++ b/shell-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shew-0/tsconfig.json
+++ b/shew-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/shumate-1.0/tsconfig.json
+++ b/shumate-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/signon-2.0/tsconfig.json
+++ b/signon-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/skk-1.0/tsconfig.json
+++ b/skk-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/snapd-1/tsconfig.json
+++ b/snapd-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/snapd-2/tsconfig.json
+++ b/snapd-2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/socialwebclient-0.25/tsconfig.json
+++ b/socialwebclient-0.25/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/soup-2.4/tsconfig.json
+++ b/soup-2.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/soup-3.0/tsconfig.json
+++ b/soup-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/soupgnome-2.4/tsconfig.json
+++ b/soupgnome-2.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/spelling-1/tsconfig.json
+++ b/spelling-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/spiceclientglib-2.0/tsconfig.json
+++ b/spiceclientglib-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/spiceclientgtk-3.0/tsconfig.json
+++ b/spiceclientgtk-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-1.0/tsconfig.json
+++ b/st-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-10/tsconfig.json
+++ b/st-10/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-11/tsconfig.json
+++ b/st-11/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-12/tsconfig.json
+++ b/st-12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-13/tsconfig.json
+++ b/st-13/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-14/tsconfig.json
+++ b/st-14/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-15/tsconfig.json
+++ b/st-15/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-16/tsconfig.json
+++ b/st-16/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-17/tsconfig.json
+++ b/st-17/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-18/tsconfig.json
+++ b/st-18/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/st-9/tsconfig.json
+++ b/st-9/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/sugarext-1.0/tsconfig.json
+++ b/sugarext-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/sugargestures-1.0/tsconfig.json
+++ b/sugargestures-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/sushi-1.0/tsconfig.json
+++ b/sushi-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/telepathyfarstream-0.6/tsconfig.json
+++ b/telepathyfarstream-0.6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/telepathyglib-0.12/tsconfig.json
+++ b/telepathyglib-0.12/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/telepathylogger-0.2/tsconfig.json
+++ b/telepathylogger-0.2/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/template-1.0/tsconfig.json
+++ b/template-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tepl-4/tsconfig.json
+++ b/tepl-4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tepl-5/tsconfig.json
+++ b/tepl-5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tepl-6/tsconfig.json
+++ b/tepl-6/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/thunarx-3.0/tsconfig.json
+++ b/thunarx-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/timezonemap-1.0/tsconfig.json
+++ b/timezonemap-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/totem-1.0/tsconfig.json
+++ b/totem-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/totemplparser-1.0/tsconfig.json
+++ b/totemplparser-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tracker-1.0/tsconfig.json
+++ b/tracker-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tracker-2.0/tsconfig.json
+++ b/tracker-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tracker-3.0/tsconfig.json
+++ b/tracker-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/trackercontrol-1.0/tsconfig.json
+++ b/trackercontrol-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/trackercontrol-2.0/tsconfig.json
+++ b/trackercontrol-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/trackerminer-1.0/tsconfig.json
+++ b/trackerminer-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/trackerminer-2.0/tsconfig.json
+++ b/trackerminer-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/translit-1.0/tsconfig.json
+++ b/translit-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/tsparql-3.0/tsconfig.json
+++ b/tsparql-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/udisks-2.0/tsconfig.json
+++ b/udisks-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/uhm-0.0/tsconfig.json
+++ b/uhm-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/uhm-1.0/tsconfig.json
+++ b/uhm-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/umockdev-1.0/tsconfig.json
+++ b/umockdev-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/unique-3.0/tsconfig.json
+++ b/unique-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/unity-6.0/tsconfig.json
+++ b/unity-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/unity-7.0/tsconfig.json
+++ b/unity-7.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/unityextras-7.0/tsconfig.json
+++ b/unityextras-7.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/upowerglib-1.0/tsconfig.json
+++ b/upowerglib-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vda-1/tsconfig.json
+++ b/vda-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vgda-1/tsconfig.json
+++ b/vgda-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vgpg-1/tsconfig.json
+++ b/vgpg-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vgsl-1/tsconfig.json
+++ b/vgsl-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vips-8.0/tsconfig.json
+++ b/vips-8.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vpg-1/tsconfig.json
+++ b/vpg-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vsqlite-1/tsconfig.json
+++ b/vsqlite-1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vte-0.0/tsconfig.json
+++ b/vte-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vte-2.91/tsconfig.json
+++ b/vte-2.91/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vte-3.91/tsconfig.json
+++ b/vte-3.91/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vte-4-2.91/tsconfig.json
+++ b/vte-4-2.91/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/vulkan-1.0/tsconfig.json
+++ b/vulkan-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit-6.0/tsconfig.json
+++ b/webkit-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2-4.0/tsconfig.json
+++ b/webkit2-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2-4.1/tsconfig.json
+++ b/webkit2-4.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2-5.0/tsconfig.json
+++ b/webkit2-5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2webextension-4.0/tsconfig.json
+++ b/webkit2webextension-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2webextension-4.1/tsconfig.json
+++ b/webkit2webextension-4.1/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkit2webextension-5.0/tsconfig.json
+++ b/webkit2webextension-5.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkitwebextension-6.0/tsconfig.json
+++ b/webkitwebextension-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/webkitwebprocessextension-6.0/tsconfig.json
+++ b/webkitwebprocessextension-6.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/win32-1.0/tsconfig.json
+++ b/win32-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/wnck-1.0/tsconfig.json
+++ b/wnck-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/wnck-3.0/tsconfig.json
+++ b/wnck-3.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/workbench-0/tsconfig.json
+++ b/workbench-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/wp-0.4/tsconfig.json
+++ b/wp-0.4/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/wp-0.5/tsconfig.json
+++ b/wp-0.5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xapp-1.0/tsconfig.json
+++ b/xapp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xdp-1.0/tsconfig.json
+++ b/xdp-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xdpgtk3-1.0/tsconfig.json
+++ b/xdpgtk3-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xdpgtk4-1.0/tsconfig.json
+++ b/xdpgtk4-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xed-1.0/tsconfig.json
+++ b/xed-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xfconf-0/tsconfig.json
+++ b/xfconf-0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xfixes-4.0/tsconfig.json
+++ b/xfixes-4.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xft-2.0/tsconfig.json
+++ b/xft-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xkl-1.0/tsconfig.json
+++ b/xkl-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xlib-2.0/tsconfig.json
+++ b/xlib-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xmlb-2.0/tsconfig.json
+++ b/xmlb-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xrandr-1.3/tsconfig.json
+++ b/xrandr-1.3/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xreaderdocument-1.5/tsconfig.json
+++ b/xreaderdocument-1.5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/xreaderview-1.5/tsconfig.json
+++ b/xreaderview-1.5/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/zbar-1.0/tsconfig.json
+++ b/zbar-1.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/zeitgeist-2.0/tsconfig.json
+++ b/zeitgeist-2.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,

--- a/zpj-0.0/tsconfig.json
+++ b/zpj-0.0/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "noEmitOnError": false,
-    "baseUrl": "./",
     "rootDir": ".",
     // General settings for code generation
     "removeComments": false,


### PR DESCRIPTION
## Summary

Drop `"baseUrl": "./"` from every `@girs/*/tsconfig.json`.

## Why

TypeScript 6.0 promoted the `baseUrl` deprecation from a warning to TS5101:

```
tsconfig.json(12,5): error TS5101: Option 'baseUrl' is deprecated and
will stop functioning in TypeScript 7.0. Specify compilerOption
'"ignoreDeprecations": "6.0"' to silence this error.
```

This breaks `yarn check:types` across every `@girs/*` package once the workspace lockfile resolves `typescript@*` to 6.0. TypeScript 4.1+ already resolves `paths` relative to the tsconfig.json directory when no `baseUrl` is set, so the option is no longer needed by these tsconfigs (the `paths` entries here all use relative `../<pkg>/index.d.ts` paths, which work fine without `baseUrl`).

## Generator

The matching template fix is in https://github.com/gjsify/ts-for-gir/pull/381 (`packages/templates/templates/tsconfig.json`). Future regenerations will produce tsconfigs without `baseUrl` automatically.

## Test plan

- [x] Sample tsc tests pass under TypeScript 6.0.3 with `baseUrl` removed: `gio-2.0`, `zpj-0.0`, `webkit2webextension-5.0`, `vte-2.91`, `gtk-4.0`.