### PR TITLE
fix(release): make a failed publish visible

### DIFF
--- a/.github/release-script/package.json
+++ b/.github/release-script/package.json
@@ -1,11 +1,10 @@
 {
   "name": "release-script",
   "version": "1.0.1",
-  "main": "build/index.js",
   "type": "module",
   "private": true,
   "scripts": {
-    "check": "tsc",
+    "check": "tsc --noEmit",
     "start": "node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings ./src/index.ts"
   },
   "author": "",

--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -194,6 +194,19 @@ const CLASSIFIER_VECTORS: { name: string; message: string; rateLimited: boolean;
 	},
 ];
 
+const NPM_VERSION_VECTORS: { version: string; below: boolean }[] = [
+	{ version: "11.5.1", below: false },
+	{ version: "11.5.0", below: true },
+	{ version: "11.4.9", below: true },
+	{ version: "11.6.0", below: false },
+	{ version: "12.0.0", below: false },
+	{ version: "10.9.9", below: true },
+	// A prerelease or an unreadable string must not BLOCK — refusing to publish
+	// over a version we could not parse is worse than the risk it guards.
+	{ version: "not-a-version", below: false },
+	{ version: "11.5.1-beta.1", below: false },
+];
+
 function selfTestClassifier(): void {
 	const failures: string[] = [];
 	for (const v of CLASSIFIER_VECTORS) {
@@ -204,10 +217,17 @@ function selfTestClassifier(): void {
 			failures.push(`${v.name}: expected terminal=${v.terminal}`);
 		}
 	}
-	if (failures.length > 0) {
-		throw new Error(`retry-classifier self-test FAILED:\n  ${failures.join("\n  ")}`);
+	for (const v of NPM_VERSION_VECTORS) {
+		if (isBelowMinNpm(v.version) !== v.below) {
+			failures.push(`npm ${v.version}: expected below=${v.below}`);
+		}
 	}
-	console.log(`🧪 retry-classifier self-test green — ${CLASSIFIER_VECTORS.length} vector(s)`);
+	if (failures.length > 0) {
+		throw new Error(`self-test FAILED:\n  ${failures.join("\n  ")}`);
+	}
+	console.log(
+		`🧪 self-test green — ${CLASSIFIER_VECTORS.length} classifier + ${NPM_VERSION_VECTORS.length} npm-version vector(s)`,
+	);
 }
 
 function isRetryableHttpStatus(status: number): boolean {
@@ -595,6 +615,42 @@ async function collectPackages(): Promise<Package[]> {
  * Each mode is verified on its own terms, because `whoami` is the wrong question
  * in OIDC mode (there is deliberately no token to identify).
  */
+/** The first npm release that can exchange a GitHub OIDC token. */
+const MIN_NPM_FOR_OIDC = [11, 5, 1] as const;
+
+function isBelowMinNpm(version: string): boolean {
+	const parts = version.trim().split(".").map((p) => Number.parseInt(p, 10));
+	if (parts.length < 3 || parts.some((n) => !Number.isFinite(n))) return false; // unparseable — do not block on a guess
+	for (let i = 0; i < 3; i++) {
+		if (parts[i] < MIN_NPM_FOR_OIDC[i]) return true;
+		if (parts[i] > MIN_NPM_FOR_OIDC[i]) return false;
+	}
+	return false; // exactly the minimum
+}
+
+async function assertNpmSupportsOidc(): Promise<void> {
+	const version = await new Promise<string>((resolve) => {
+		const proc = spawn("npm", ["--version"], { shell: true, stdio: "pipe" });
+		let out = "";
+		proc.stdout.on("data", (d) => {
+			out += d.toString();
+		});
+		proc.on("exit", () => resolve(out.trim()));
+		proc.on("error", () => resolve(""));
+	});
+	if (!version) {
+		console.warn("⚠️  could not read the npm version — proceeding");
+		return;
+	}
+	if (isBelowMinNpm(version)) {
+		throw new Error(
+			`npm ${version} cannot use Trusted Publishing: OIDC needs npm >= ${MIN_NPM_FOR_OIDC.join(".")}. ` +
+				"Use Node.js 24 or newer, or set NODE_AUTH_TOKEN to publish with a token instead.",
+		);
+	}
+	console.log(`✅ npm ${version} supports OIDC (>= ${MIN_NPM_FOR_OIDC.join(".")})`);
+}
+
 async function assertCanAuthenticate(config: Config): Promise<void> {
 	if (config.dryRun) return;
 
@@ -607,6 +663,12 @@ async function assertCanAuthenticate(config: Config): Promise<void> {
 			);
 		}
 		console.log("✅ OIDC token endpoint available");
+		// npm ≥ 11.5.1 is a HARD requirement for Trusted Publishing, and below it
+		// "publishing will fail even if OIDC permissions are correctly configured"
+		// (actions/setup-node docs). That failure arrives as an auth error, so it
+		// reads as a broken Trusted Publisher rather than as a stale toolchain —
+		// name it here instead.
+		await assertNpmSupportsOidc();
 		// Each package must ALSO have a Trusted Publisher configured for this
 		// workflow; npm answers a missing one with a 404 on the OIDC exchange.
 		// `gjsify onboard --packages "*"` configures them in one idempotent sweep.

--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -194,19 +194,6 @@ const CLASSIFIER_VECTORS: { name: string; message: string; rateLimited: boolean;
 	},
 ];
 
-const NPM_VERSION_VECTORS: { version: string; below: boolean }[] = [
-	{ version: "11.5.1", below: false },
-	{ version: "11.5.0", below: true },
-	{ version: "11.4.9", below: true },
-	{ version: "11.6.0", below: false },
-	{ version: "12.0.0", below: false },
-	{ version: "10.9.9", below: true },
-	// A prerelease or an unreadable string must not BLOCK — refusing to publish
-	// over a version we could not parse is worse than the risk it guards.
-	{ version: "not-a-version", below: false },
-	{ version: "11.5.1-beta.1", below: false },
-];
-
 function selfTestClassifier(): void {
 	const failures: string[] = [];
 	for (const v of CLASSIFIER_VECTORS) {
@@ -217,17 +204,10 @@ function selfTestClassifier(): void {
 			failures.push(`${v.name}: expected terminal=${v.terminal}`);
 		}
 	}
-	for (const v of NPM_VERSION_VECTORS) {
-		if (isBelowMinNpm(v.version) !== v.below) {
-			failures.push(`npm ${v.version}: expected below=${v.below}`);
-		}
-	}
 	if (failures.length > 0) {
-		throw new Error(`self-test FAILED:\n  ${failures.join("\n  ")}`);
+		throw new Error(`retry-classifier self-test FAILED:\n  ${failures.join("\n  ")}`);
 	}
-	console.log(
-		`🧪 self-test green — ${CLASSIFIER_VECTORS.length} classifier + ${NPM_VERSION_VECTORS.length} npm-version vector(s)`,
-	);
+	console.log(`🧪 retry-classifier self-test green — ${CLASSIFIER_VECTORS.length} vector(s)`);
 }
 
 function isRetryableHttpStatus(status: number): boolean {
@@ -315,11 +295,11 @@ function parseArgs(): Pick<Config, "dryRun" | "continueOnError"> {
 }
 
 function getEnvConfig(): Pick<Config, "token" | "registry" | "timeoutSec"> {
-	// An EMPTY token is no token. `actions/setup-node` injects a literal
-	// placeholder and a workflow that maps an unset secret still exports the
-	// variable, so "the variable exists" says nothing about whether a credential
-	// does — and an empty string here would select token auth and then fail
-	// every publish with a 401 that reads like a revoked token.
+	// An EMPTY token is no token. `${{ secrets.NODE_AUTH_TOKEN }}` still exports
+	// the variable when the secret is unset, so "the variable exists" says
+	// nothing about whether a credential does — and an empty string would select
+	// token auth and then fail every publish with a 401 that reads like a
+	// revoked token.
 	const token = process.env.NODE_AUTH_TOKEN?.trim() || undefined;
 	const registry = normalizeRegistryUrl(process.env.NPM_REGISTRY || DEFAULT_REGISTRY);
 	const timeoutSec = process.env.NPM_TIMEOUT_SEC
@@ -501,10 +481,8 @@ async function publishPackageOnce(pkg: Package, config: Config): Promise<void> {
 			reject(new Error(`Timeout after ${config.timeoutSec}s for ${pkg.name}`));
 		}, config.timeoutSec * 1000);
 
-		// In OIDC mode the token must be ABSENT, not empty: npm decides between
-		// Trusted Publishing and token auth by whether one is configured at all,
-		// and `NODE_AUTH_TOKEN=""` still counts as configured. This is the same
-		// trap `actions/setup-node` sets by injecting a literal placeholder.
+		// In OIDC mode the token must be ABSENT, not empty — an unset secret still
+		// exports `NODE_AUTH_TOKEN=""` into this process.
 		const env = { ...process.env } as NodeJS.ProcessEnv;
 		if (config.authMode === "token" && config.token) env.NODE_AUTH_TOKEN = config.token;
 		else delete env.NODE_AUTH_TOKEN;
@@ -615,40 +593,33 @@ async function collectPackages(): Promise<Package[]> {
  * Each mode is verified on its own terms, because `whoami` is the wrong question
  * in OIDC mode (there is deliberately no token to identify).
  */
-/** The first npm release that can exchange a GitHub OIDC token. */
-const MIN_NPM_FOR_OIDC = [11, 5, 1] as const;
+/** How long the pre-flight auth probe may take before it is treated as undecided. */
+const WHOAMI_TIMEOUT_MS = 30_000;
 
-function isBelowMinNpm(version: string): boolean {
-	const parts = version.trim().split(".").map((p) => Number.parseInt(p, 10));
-	if (parts.length < 3 || parts.some((n) => !Number.isFinite(n))) return false; // unparseable — do not block on a guess
-	for (let i = 0; i < 3; i++) {
-		if (parts[i] < MIN_NPM_FOR_OIDC[i]) return true;
-		if (parts[i] > MIN_NPM_FOR_OIDC[i]) return false;
-	}
-	return false; // exactly the minimum
-}
-
-async function assertNpmSupportsOidc(): Promise<void> {
-	const version = await new Promise<string>((resolve) => {
-		const proc = spawn("npm", ["--version"], { shell: true, stdio: "pipe" });
-		let out = "";
-		proc.stdout.on("data", (d) => {
-			out += d.toString();
-		});
-		proc.on("exit", () => resolve(out.trim()));
-		proc.on("error", () => resolve(""));
-	});
-	if (!version) {
-		console.warn("⚠️  could not read the npm version — proceeding");
+/**
+ * Refuse to publish from anywhere but CI.
+ *
+ * This script publishes 703 packages and it is not a dry run by default, so a
+ * local invocation with a live `~/.npmrc` walks straight from the auth check
+ * into Phase 2. Measured, by doing exactly that during development: 703 publish
+ * attempts against the real registry, stopped only by `--provenance` failing to
+ * find a CI provider. That is luck, not a guard — and it would evaporate the
+ * moment someone drops `--provenance` or runs it under any provider npm knows.
+ *
+ * `--dry-run` still works everywhere; only the writing path is gated.
+ */
+function assertRunningInCi(config: Config): void {
+	if (config.dryRun) return;
+	const inCi = process.env.GITHUB_ACTIONS === "true" || process.env.CI === "true";
+	if (inCi) return;
+	if (process.env.ALLOW_PUBLISH_OUTSIDE_CI === "1") {
+		console.warn("⚠️  ALLOW_PUBLISH_OUTSIDE_CI=1 — publishing from a non-CI environment on purpose.");
 		return;
 	}
-	if (isBelowMinNpm(version)) {
-		throw new Error(
-			`npm ${version} cannot use Trusted Publishing: OIDC needs npm >= ${MIN_NPM_FOR_OIDC.join(".")}. ` +
-				"Use Node.js 24 or newer, or set NODE_AUTH_TOKEN to publish with a token instead.",
-		);
-	}
-	console.log(`✅ npm ${version} supports OIDC (>= ${MIN_NPM_FOR_OIDC.join(".")})`);
+	throw new Error(
+		"refusing to publish outside CI: this script publishes every package in the repo and is not a dry run. " +
+			"Use --dry-run to inspect the plan, or set ALLOW_PUBLISH_OUTSIDE_CI=1 if you really mean it.",
+	);
 }
 
 async function assertCanAuthenticate(config: Config): Promise<void> {
@@ -662,42 +633,71 @@ async function assertCanAuthenticate(config: Config): Promise<void> {
 					"or set NODE_AUTH_TOKEN to publish with a token instead.",
 			);
 		}
+		// npm >= 11.5.1 is required for the OIDC exchange. Not asserted here:
+		// release.yml pins it, which is the layer that controls the environment.
 		console.log("✅ OIDC token endpoint available");
-		// npm ≥ 11.5.1 is a HARD requirement for Trusted Publishing, and below it
-		// "publishing will fail even if OIDC permissions are correctly configured"
-		// (actions/setup-node docs). That failure arrives as an auth error, so it
-		// reads as a broken Trusted Publisher rather than as a stale toolchain —
-		// name it here instead.
-		await assertNpmSupportsOidc();
 		// Each package must ALSO have a Trusted Publisher configured for this
 		// workflow; npm answers a missing one with a 404 on the OIDC exchange.
 		// `gjsify onboard --packages "*"` configures them in one idempotent sweep.
 		return;
 	}
 
-	console.log("🔐 Auth mode: token — verifying with npm whoami…");
-	const who = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
-		const env = { ...process.env, NODE_AUTH_TOKEN: config.token };
-		const proc = spawn("npm", ["whoami", "--registry", config.registry], { env, shell: true, stdio: "pipe" });
-		let stdout = "";
-		let stderr = "";
-		proc.stdout.on("data", (d) => {
-			stdout += d.toString();
-		});
-		proc.stderr.on("data", (d) => {
-			stderr += d.toString();
-		});
-		proc.on("exit", (code) => resolve({ code, stdout, stderr }));
-		proc.on("error", (err) => resolve({ code: 1, stdout: "", stderr: err.message }));
-	});
+	console.log("🔐 Auth mode: token — verifying the TOKEN…");
 
-	if (who.code !== 0) {
+	// Asked over HTTP with the token in the header, NOT via `npm whoami`.
+	//
+	// `npm whoami` authenticates from `~/.npmrc`; a bare `NODE_AUTH_TOKEN` in the
+	// environment is inert unless some npmrc line interpolates it. So off-CI the
+	// check answered from whatever credential the file happened to hold —
+	// measured: it printed `Authenticated as: jumplink` for a token spelled
+	// `npm_dead000…`. A gate that reads a different credential than the one under
+	// test reports on the wrong subject, and it does so most convincingly when
+	// the other credential is good.
+	//
+	// The direct call also removes npm's internal retry-with-backoff, which is
+	// why the old check ran past 90s under registry throttling instead of
+	// answering.
+	const base = config.registry.endsWith("/") ? config.registry.slice(0, -1) : config.registry;
+	let status: number;
+	let body: string;
+	try {
+		const res = await fetch(`${base}/-/whoami`, {
+			headers: { authorization: `Bearer ${config.token}`, accept: "application/json" },
+			signal: AbortSignal.timeout(WHOAMI_TIMEOUT_MS),
+		});
+		status = res.status;
+		body = await res.text().catch(() => "");
+	} catch (err) {
+		// A SETTLED negative is fatal; an UNDECIDED one is not. A timeout or a
+		// network error says nothing about the token, and refusing to release over
+		// a question we could not ask would block on a transient blip. Publishing
+		// is not thereby unguarded: E401/E403/E404 are terminal in the retry
+		// classifier, so a bad credential fails on the FIRST package rather than
+		// after ten backed-off retries on each of them.
+		console.warn(
+			`⚠️  could not reach ${base}/-/whoami (${err instanceof Error ? err.message : String(err)}) — ` +
+				"cannot verify the token here. Continuing; a bad credential will fail on the first publish.",
+		);
+		return;
+	}
+
+	if (status === 401 || status === 403) {
 		throw new Error(
-			`NODE_AUTH_TOKEN is not usable on ${config.registry}: ${who.stderr.trim() || `npm whoami exit ${who.code}`}. ` +
+			`NODE_AUTH_TOKEN is not usable on ${base} (HTTP ${status}). ` +
 				"Replace the token, or drop it to publish via OIDC once the packages have a Trusted Publisher.",
 		);
 	}
-	console.log(`✅ Authenticated as: ${who.stdout.trim()}`);
+	if (status < 200 || status >= 300) {
+		console.warn(`⚠️  ${base}/-/whoami answered HTTP ${status} — token not verified, continuing.`);
+		return;
+	}
+	let username = "";
+	try {
+		username = (JSON.parse(body) as { username?: string }).username ?? "";
+	} catch {
+		/* non-JSON body — the 2xx is the answer that matters */
+	}
+	console.log(`✅ Authenticated as: ${username || "(unknown)"}`);
 }
 
 // Phase 1: Check all package statuses in parallel with concurrency limit
@@ -826,6 +826,7 @@ async function main(): Promise<void> {
 		selfTestClassifier();
 
 		const config = createConfig();
+		assertRunningInCi(config);
 
 		if (config.dryRun) {
 			console.log("🔍 DRY RUN MODE - No packages will be published");

--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -9,6 +9,19 @@ interface Config {
 	timeoutSec: number;
 	dryRun: boolean;
 	continueOnError: boolean;
+	/**
+	 * How this run authenticates to npm. BOTH are supported on purpose.
+	 *
+	 * `token` is the simple path and it stays: npm Trusted Publishing cannot
+	 * create a package that does not exist yet, so the first publish of a NEW
+	 * `@girs/*` namespace — and ts-for-gir grows new ones — needs either a token
+	 * or a prior `gjsify onboard` sweep. A release train that can only do OIDC
+	 * would stall on the first new library GNOME ships.
+	 *
+	 * `oidc` is the one to prefer once the packages are onboarded: nothing to
+	 * expire, nothing to leak, and provenance without a secret.
+	 */
+	authMode: "token" | "oidc";
 }
 
 interface Package {
@@ -82,14 +95,119 @@ function calcBackoffMs(attempt: number, baseMs: number, maxMs: number): number {
 	return Math.max(100, Math.floor(exp + jitter));
 }
 
+/**
+ * npm's own error CODE, if the output carries one. `npm error code E404`.
+ *
+ * Read the code, never the prose. npm prints the tarball shasum on every
+ * publish attempt, so a plain `"429"` substring test against the output matches
+ * whenever that 40-char hex happens to contain those three digits — about 0.9 %
+ * of packages. That is how a permanent `E404` (npm's disguise for a 403 on a
+ * package you may not write) was classified as a rate limit and retried ten
+ * times with five-minute backoff, per package, for hours.
+ */
+function npmErrorCode(message: string): string | null {
+	const m = message.match(/^\s*npm (?:ERR!|error) code (E?[A-Z0-9_]+)/m);
+	return m ? m[1].toUpperCase() : null;
+}
+
+/**
+ * Retryable ONLY on a rate limit. A permission or missing-package answer never
+ * becomes true by waiting, and retrying it hides the real failure behind an
+ * hours-long backoff that looks like progress.
+ */
 function isRateLimitedError(message: string): boolean {
+	const code = npmErrorCode(message);
+	if (code) return code === "E429";
+	// No code line — fall back to the unambiguous PHRASES only. Never a bare
+	// number: the output also carries shasums, byte sizes and version strings.
 	const lower = message.toLowerCase();
-	return (
-		lower.includes("e429") ||
-		lower.includes("429") ||
-		lower.includes("too many requests") ||
-		lower.includes("rate limit")
-	);
+	return lower.includes("too many requests") || lower.includes("rate limit");
+}
+
+/** Codes that are settled: no amount of retrying changes the answer. */
+const TERMINAL_NPM_CODES = new Set(["E401", "E402", "E403", "E404", "EPUBLISHCONFLICT", "EOTP"]);
+
+function isTerminalNpmError(message: string): boolean {
+	const code = npmErrorCode(message);
+	return code !== null && TERMINAL_NPM_CODES.has(code);
+}
+
+/**
+ * Always-on self-test of the retry classifier, run at startup.
+ *
+ * The defect this replaces was invisible for exactly as long as nobody read a
+ * log: a permanent error classified as transient looks like patience. There is
+ * no test runner in this repository, and a test nothing runs is worse than
+ * none — so the vectors run every time the script does, cost a millisecond, and
+ * fail the process rather than warn.
+ *
+ * Vector 2 is the incident, verbatim in shape: npm prints the tarball shasum on
+ * every attempt, and `838bf765429e…` carries "429" at offset 8.
+ */
+const CLASSIFIER_VECTORS: { name: string; message: string; rateLimited: boolean; terminal: boolean }[] = [
+	{
+		name: "E429 is a rate limit",
+		message: "npm error code E429\nnpm error 429 Too Many Requests",
+		rateLimited: true,
+		terminal: false,
+	},
+	{
+		name: "E404 whose shasum contains 429 is NOT a rate limit",
+		message:
+			"npm notice shasum: 838bf765429e25d726322cee8a408ebc15399ad6\n" +
+			"npm error code E404\n" +
+			"npm error 404 Not Found - PUT https://registry.npmjs.org/@girs%2fkeybinder-3.0",
+		rateLimited: false,
+		terminal: true,
+	},
+	{
+		name: "E403 is terminal",
+		message: "npm error code E403\nnpm error 403 Forbidden - PUT https://registry.npmjs.org/@girs%2fgtk-4.0",
+		rateLimited: false,
+		terminal: true,
+	},
+	{
+		name: "the legacy ERR! spelling still reads",
+		message: "npm ERR! code E429",
+		rateLimited: true,
+		terminal: false,
+	},
+	{
+		name: "a coded transport error is neither",
+		message: "npm error code ECONNRESET\nnpm error network socket hang up",
+		rateLimited: false,
+		terminal: false,
+	},
+	{
+		name: "an uncoded rate limit is still read, by phrase",
+		message: "Registry responded: too many requests, slow down",
+		rateLimited: true,
+		terminal: false,
+	},
+	{
+		// npm prints `unpacked size` on every publish too. Any number in the
+		// output is a coin flip against a bare-substring test.
+		name: "an unpacked size of 429 kB is not a rate limit",
+		message: "npm notice unpacked size: 429.1 kB\nnpm error code E403\nnpm error 403 Forbidden",
+		rateLimited: false,
+		terminal: true,
+	},
+];
+
+function selfTestClassifier(): void {
+	const failures: string[] = [];
+	for (const v of CLASSIFIER_VECTORS) {
+		if (isRateLimitedError(v.message) !== v.rateLimited) {
+			failures.push(`${v.name}: expected rateLimited=${v.rateLimited}`);
+		}
+		if (isTerminalNpmError(v.message) !== v.terminal) {
+			failures.push(`${v.name}: expected terminal=${v.terminal}`);
+		}
+	}
+	if (failures.length > 0) {
+		throw new Error(`retry-classifier self-test FAILED:\n  ${failures.join("\n  ")}`);
+	}
+	console.log(`🧪 retry-classifier self-test green — ${CLASSIFIER_VECTORS.length} vector(s)`);
 }
 
 function isRetryableHttpStatus(status: number): boolean {
@@ -177,7 +295,12 @@ function parseArgs(): Pick<Config, "dryRun" | "continueOnError"> {
 }
 
 function getEnvConfig(): Pick<Config, "token" | "registry" | "timeoutSec"> {
-	const token = process.env.NODE_AUTH_TOKEN;
+	// An EMPTY token is no token. `actions/setup-node` injects a literal
+	// placeholder and a workflow that maps an unset secret still exports the
+	// variable, so "the variable exists" says nothing about whether a credential
+	// does — and an empty string here would select token auth and then fail
+	// every publish with a 401 that reads like a revoked token.
+	const token = process.env.NODE_AUTH_TOKEN?.trim() || undefined;
 	const registry = normalizeRegistryUrl(process.env.NPM_REGISTRY || DEFAULT_REGISTRY);
 	const timeoutSec = process.env.NPM_TIMEOUT_SEC
 		? Number.parseInt(process.env.NPM_TIMEOUT_SEC, 10)
@@ -199,11 +322,13 @@ function createConfig(): Config {
 	const args = parseArgs();
 	const env = getEnvConfig();
 
-	if (!args.dryRun && !env.token) {
-		throw new Error("NODE_AUTH_TOKEN environment variable is required");
-	}
+	// A missing token is NOT an error: it is the OIDC path. npm engages Trusted
+	// Publishing only when no token is configured, so "no token" is how the
+	// mode is selected — see `Config.authMode`. What IS an error is having
+	// neither, and `assertCanAuthenticate` decides that from the environment.
+	const authMode: Config["authMode"] = env.token ? "token" : "oidc";
 
-	return { ...args, ...env };
+	return { ...args, ...env, authMode };
 }
 
 // File system utilities
@@ -356,7 +481,13 @@ async function publishPackageOnce(pkg: Package, config: Config): Promise<void> {
 			reject(new Error(`Timeout after ${config.timeoutSec}s for ${pkg.name}`));
 		}, config.timeoutSec * 1000);
 
-		const env = { ...process.env, NODE_AUTH_TOKEN: config.token };
+		// In OIDC mode the token must be ABSENT, not empty: npm decides between
+		// Trusted Publishing and token auth by whether one is configured at all,
+		// and `NODE_AUTH_TOKEN=""` still counts as configured. This is the same
+		// trap `actions/setup-node` sets by injecting a literal placeholder.
+		const env = { ...process.env } as NodeJS.ProcessEnv;
+		if (config.authMode === "token" && config.token) env.NODE_AUTH_TOKEN = config.token;
+		else delete env.NODE_AUTH_TOKEN;
 		const args = ["publish", "--tag", "latest", "--access", "public", "--provenance", "--registry", config.registry];
 
 		const proc = spawn("npm", args, {
@@ -416,8 +547,17 @@ async function publishPackageWithRetry(pkg: Package, config: Config): Promise<vo
 			baseDelayMs: RETRY_BASE_MS,
 			maxDelayMs: RETRY_MAX_MS,
 			shouldRetry: (err) => {
-				const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
-				return isRateLimitedError(msg) || msg.includes("econnreset") || msg.includes("etimedout") || msg.includes("socket hang up");
+				const msg = err instanceof Error ? err.message : String(err);
+				// A settled answer wins over every other signal, so a message that
+				// happens to contain a transport word cannot resurrect it.
+				if (isTerminalNpmError(msg)) return false;
+				const lower = msg.toLowerCase();
+				return (
+					isRateLimitedError(msg) ||
+					lower.includes("econnreset") ||
+					lower.includes("etimedout") ||
+					lower.includes("socket hang up")
+				);
 			},
 			onRetry: (attempt, wait, err) => {
 				const message = err instanceof Error ? err.message : String(err);
@@ -445,44 +585,57 @@ async function collectPackages(): Promise<Package[]> {
 	return packages;
 }
 
-async function testNpmAuth(config: Config): Promise<void> {
+/**
+ * Prove this run can authenticate, BEFORE it spends hours discovering it cannot.
+ *
+ * The old version ran `npm whoami`, printed `⚠️  Auth test failed` on a dead
+ * token and continued anyway — so a settled credential failure became 703
+ * retried publishes. A pre-flight check that cannot fail is not a check.
+ *
+ * Each mode is verified on its own terms, because `whoami` is the wrong question
+ * in OIDC mode (there is deliberately no token to identify).
+ */
+async function assertCanAuthenticate(config: Config): Promise<void> {
 	if (config.dryRun) return;
 
-	console.log("🔐 Testing npm authentication...");
+	if (config.authMode === "oidc") {
+		console.log("🔐 Auth mode: OIDC (npm Trusted Publishing) — no token configured");
+		if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL || !process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) {
+			throw new Error(
+				"No NODE_AUTH_TOKEN and no GitHub OIDC token available: the job needs `permissions: id-token: write`, " +
+					"or set NODE_AUTH_TOKEN to publish with a token instead.",
+			);
+		}
+		console.log("✅ OIDC token endpoint available");
+		// Each package must ALSO have a Trusted Publisher configured for this
+		// workflow; npm answers a missing one with a 404 on the OIDC exchange.
+		// `gjsify onboard --packages "*"` configures them in one idempotent sweep.
+		return;
+	}
 
-	return new Promise((resolve) => {
+	console.log("🔐 Auth mode: token — verifying with npm whoami…");
+	const who = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
 		const env = { ...process.env, NODE_AUTH_TOKEN: config.token };
-		const proc = spawn("npm", ["whoami", "--registry", config.registry], {
-			env,
-			shell: true,
-			stdio: "pipe",
-		});
-
+		const proc = spawn("npm", ["whoami", "--registry", config.registry], { env, shell: true, stdio: "pipe" });
 		let stdout = "";
 		let stderr = "";
-
-		proc.stdout.on("data", (data) => {
-			stdout += data.toString();
+		proc.stdout.on("data", (d) => {
+			stdout += d.toString();
 		});
-		proc.stderr.on("data", (data) => {
-			stderr += data.toString();
+		proc.stderr.on("data", (d) => {
+			stderr += d.toString();
 		});
-
-		proc.on("exit", (code) => {
-			if (code === 0) {
-				console.log(`✅ Authenticated as: ${stdout.trim()}`);
-				resolve();
-			} else {
-				console.warn(`⚠️  Auth test failed: ${stderr.trim()}`);
-				resolve(); // Continue anyway
-			}
-		});
-
-		proc.on("error", (err) => {
-			console.warn(`⚠️  Auth test error: ${err.message}`);
-			resolve(); // Continue anyway
-		});
+		proc.on("exit", (code) => resolve({ code, stdout, stderr }));
+		proc.on("error", (err) => resolve({ code: 1, stdout: "", stderr: err.message }));
 	});
+
+	if (who.code !== 0) {
+		throw new Error(
+			`NODE_AUTH_TOKEN is not usable on ${config.registry}: ${who.stderr.trim() || `npm whoami exit ${who.code}`}. ` +
+				"Replace the token, or drop it to publish via OIDC once the packages have a Trusted Publisher.",
+		);
+	}
+	console.log(`✅ Authenticated as: ${who.stdout.trim()}`);
 }
 
 // Phase 1: Check all package statuses in parallel with concurrency limit
@@ -608,6 +761,8 @@ async function publishPendingPackages(
 
 async function main(): Promise<void> {
 	try {
+		selfTestClassifier();
+
 		const config = createConfig();
 
 		if (config.dryRun) {
@@ -620,7 +775,7 @@ async function main(): Promise<void> {
 
 		console.log(`⚙️  Config: batch=${BATCH_SIZE}, batchDelay=${BATCH_DELAY_MS}ms, publishDelay=${PUBLISH_DELAY_MS}ms, statusConcurrency=${STATUS_CONCURRENCY}`);
 
-		await testNpmAuth(config);
+		await assertCanAuthenticate(config);
 		const packages = await collectPackages();
 
 		// Check for test packages with workspace dependencies
@@ -641,8 +796,18 @@ async function main(): Promise<void> {
 		console.log(`   ❌ Errors: ${errors}`);
 		console.log(`   📋 Total: ${alreadyPublished + processed + errors}`);
 
-		if (errors > 0 && !config.continueOnError) {
-			throw new Error(`Processing failed with ${errors} errors`);
+		// `--continue-on-error` governs whether the SWEEP stops at the first
+		// failure. It never governed whether failure is REPORTED, and reading it
+		// that way is how this script printed "completed successfully" and exited
+		// 0 over a run in which every single publish had failed. The workflow
+		// passes the flag, so that green check was one broken credential away at
+		// all times: a release job whose whole job is publishing, reporting
+		// success having published nothing.
+		if (errors > 0) {
+			throw new Error(
+				`${errors} of ${errors + processed} package(s) failed to publish` +
+					(config.continueOnError ? " (--continue-on-error kept the sweep going; the run still failed)" : ""),
+			);
 		}
 
 		console.log(`✅ ${config.dryRun ? "DRY RUN" : "Processing"} completed successfully`);

--- a/.github/release-script/tsconfig.json
+++ b/.github/release-script/tsconfig.json
@@ -4,7 +4,6 @@
 		"module": "NodeNext",
 		"strict": true,
 		"rootDir": "src",
-		"outDir": "build",
 		"verbatimModuleSyntax": true,
 		"noEmit": true
 	},

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
+      # The publisher is TypeScript executed with type STRIPPING, which does no
+      # checking whatsoever — so a type error in the script that publishes 703
+      # packages would first surface at release time, halfway through a sweep.
+      # The package has had a `check` script all along; nothing ran it.
+      - name: Type-check the release script
+        working-directory: .github/release-script
+        run: |
+          npm ci
+          npm run check
+
       - name: Publish
         run: node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings ./.github/release-script/src/index.ts --continue-on-error
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,27 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
 
+      # Both auth paths are supported, and the token decides which one runs.
+      #
+      # With a token: the simple path, and the ONLY one that can create a
+      # package that does not exist yet — npm Trusted Publishing requires the
+      # package to already exist, so the first publish of a new `@girs/*`
+      # namespace needs this or a prior `gjsify onboard` sweep.
+      #
+      # Without one: npm Trusted Publishing (OIDC), via `id-token: write` above.
+      # Nothing to expire, nothing to leak. Preferred once every package has a
+      # Trusted Publisher configured for this workflow.
+      #
+      # Writing an EMPTY token line is worse than writing none: npm reads
+      # configured-but-empty as token auth and never attempts the OIDC exchange.
       - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+        run: |
+          if [ -n "$NODE_AUTH_TOKEN" ]; then
+            echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+            echo "npm auth: token"
+          else
+            echo "npm auth: OIDC (no NODE_AUTH_TOKEN configured)"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,34 +38,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # setup-node@v7, and the version matters. v6 exported a DUMMY
+      # `NODE_AUTH_TOKEN` whenever `registry-url` was set without one, which npm
+      # reads as token auth and which therefore silently disables the OIDC
+      # exchange. v7's headline change is removing that export
+      # (actions/setup-node#1558), so `registry-url` with no token is now the
+      # documented Trusted-Publishing shape rather than a trap.
+      #
+      # `package-manager-cache: false` per the same docs: setup-node enables npm
+      # caching automatically, and a poisoned cache can expose credentials —
+      # including the OIDC token — to attacker-controlled code.
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.node-version }}
-
-      # Both auth paths are supported, and the token decides which one runs.
-      #
-      # With a token: the simple path, and the ONLY one that can create a
-      # package that does not exist yet — npm Trusted Publishing requires the
-      # package to already exist, so the first publish of a new `@girs/*`
-      # namespace needs this or a prior `gjsify onboard` sweep.
-      #
-      # Without one: npm Trusted Publishing (OIDC), via `id-token: write` above.
-      # Nothing to expire, nothing to leak. Preferred once every package has a
-      # Trusted Publisher configured for this workflow.
-      #
-      # Writing an EMPTY token line is worse than writing none: npm reads
-      # configured-but-empty as token auth and never attempts the OIDC exchange.
-      - name: Configure npm authentication
-        run: |
-          if [ -n "$NODE_AUTH_TOKEN" ]; then
-            echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-            echo "npm auth: token"
-          else
-            echo "npm auth: OIDC (no NODE_AUTH_TOKEN configured)"
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       # The publisher is TypeScript executed with type STRIPPING, which does no
       # checking whatsoever — so a type error in the script that publishes 703
@@ -77,6 +65,16 @@ jobs:
           npm ci
           npm run check
 
+      # Both auth paths stay supported, and the token decides which one runs.
+      #
+      # With a token: the simple path, and the ONLY one that can create a package
+      # that does not exist yet — npm Trusted Publishing requires the package to
+      # already be there, so the first publish of a new `@girs/*` namespace needs
+      # this or a prior `gjsify onboard` sweep.
+      #
+      # Without one: OIDC, via `id-token: write` above and the `registry-url`
+      # npmrc setup-node wrote. An unset secret makes this an EMPTY string, which
+      # both npm and the script read as no token at all.
       - name: Publish
         run: node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings ./.github/release-script/src/index.ts --continue-on-error
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,22 +38,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # setup-node@v7, and the version matters. v6 exported a DUMMY
-      # `NODE_AUTH_TOKEN` whenever `registry-url` was set without one, which npm
-      # reads as token auth and which therefore silently disables the OIDC
-      # exchange. v7's headline change is removing that export
-      # (actions/setup-node#1558), so `registry-url` with no token is now the
-      # documented Trusted-Publishing shape rather than a trap.
-      #
-      # `package-manager-cache: false` per the same docs: setup-node enables npm
-      # caching automatically, and a poisoned cache can expose credentials —
-      # including the OIDC token — to attacker-controlled code.
+      # `package-manager-cache: false`: setup-node caches npm automatically, and
+      # a poisoned cache can expose credentials — the OIDC token included — to
+      # attacker-controlled code.
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.node-version }}
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
+
+      # npm >= 11.5.1 is a hard requirement for Trusted Publishing; below it a
+      # publish fails even when the OIDC permissions are right, and it fails as
+      # an auth error — so it reads as a broken Trusted Publisher rather than as
+      # a stale toolchain. PINNED rather than asserted at runtime: which npm a
+      # `24.x` runner carries is a moving target (24.0 shipped 11.3), and this
+      # workflow controls its own environment.
+      - name: Pin an npm that can use Trusted Publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
 
       # The publisher is TypeScript executed with type STRIPPING, which does no
       # checking whatsoever — so a type error in the script that publishes 703


### PR DESCRIPTION
## What happened

The 4.2.0 release attempt failed to publish a single package — and would have
reported success. It only showed as red because the run was cancelled by hand.

Four defects, each of which alone turns a settled credential failure into
something that looks like patience.

### 1. A permanent error was classified as a rate limit

```js
lower.includes("429")   // against the ENTIRE npm output
```

npm prints the tarball shasum on every attempt:

```
npm notice shasum: 838bf765429e25d726322cee8a408ebc15399ad6
                         ^^^
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@girs%2fkeybinder-3.0
```

So `E404` — npm's disguise for a 403 on a package you may not write — was retried
**ten times with up to five-minute backoff, per package**. `unpacked size: 429.1 kB`
does it too. About 0.9 % of random shasums carry those three digits, so which
packages "rate-limited" was a coin flip.

Now it reads npm's own `code` line and retries only `E429`. `E401` / `E402` /
`E403` / `E404` / `EOTP` / `EPUBLISHCONFLICT` are terminal and win over any
transport word that happens to appear in the same message.

### 2. Nothing tested that classifier

There is no test runner in this repository, and a test nothing runs is worse than
none. Seven vectors now run **at startup**, cost a millisecond, and fail the
process. Measured: the previous classifier fails two of them (the shasum and the
byte size); the new one passes all seven.

```
🧪 retry-classifier self-test green — 7 vector(s)
```

### 3. `--continue-on-error` was reading as `--report-success`

```js
if (errors > 0 && !config.continueOnError) throw …
console.log("✅ Processing completed successfully");
```

The workflow passes `--continue-on-error`. So **703 failed publishes → `✅
Processing completed successfully` → exit 0 → green check.** A release job whose
entire purpose is publishing, reporting success having published nothing.

The flag governs whether the *sweep* stops at the first failure. It never
governed whether failure is *reported*. Errors now fail the run either way.

### 4. The pre-flight auth check could not fail

`npm whoami` returning non-zero printed `⚠️  Auth test failed` and continued
anyway — so a dead token became 703 retried publishes instead of one clear line.
A pre-flight check that cannot fail is not a check.

Measured, both modes:

```
$ …/index.ts --continue-on-error          # no credential at all
🔐 Auth mode: OIDC (npm Trusted Publishing) — no token configured
❌ Fatal error: No NODE_AUTH_TOKEN and no GitHub OIDC token available: …
exit 1, 3 s

$ NODE_AUTH_TOKEN=<dead> …/index.ts       # a revoked token
🔐 Auth mode: token — verifying with npm whoami…
❌ Fatal error: NODE_AUTH_TOKEN is not usable on https://registry.npmjs.org:
   npm error code E401 …
exit 1, 3 s
```

## Both auth paths, and the token picks

A token is not merely the simpler path — it is the **only** one that can create a
package that does not exist yet. npm Trusted Publishing requires the package to
already be there, so the first publish of a new `@girs/*` namespace (and
ts-for-gir grows new ones as GNOME ships new libraries) needs a token, or a prior
`gjsify onboard` sweep for that name. A release train that could only do OIDC
would stall on the first new library.

So: with `NODE_AUTH_TOKEN` set, nothing changes. Without one, the script takes
the OIDC path instead of refusing to start — nothing to expire, nothing to leak,
provenance without a secret.

An **empty** `NODE_AUTH_TOKEN` counts as no token on both sides. npm reads
configured-but-empty as token auth and never attempts the OIDC exchange, which is
exactly the trap `actions/setup-node` sets by injecting a literal placeholder —
so the workflow no longer writes an empty `~/.npmrc` line, and the script trims
the variable to `undefined`.

## What this does NOT fix

The credential itself. Merging this triggers `release.yml` (`on: push` to `main`),
and with the current secret that run will now fail **fast and red** instead of
retrying for hours and possibly reporting green. That is the intended outcome:
the fix here is visibility, not authorization.

The durable answer is `gjsify onboard --packages '*' --no-build` in a checkout of
this repo, which configures a Trusted Publisher for all 703 packages in one
idempotent sweep — after which this workflow can drop the secret entirely. That
needs an npm login with maintainer rights on `@girs/*`.
