### PR TITLE
fix(release): retry a transient registry conflict

### DIFF
--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -127,9 +127,36 @@ function isRateLimitedError(message: string): boolean {
 /** Codes that are settled: no amount of retrying changes the answer. */
 const TERMINAL_NPM_CODES = new Set(["E401", "E402", "E403", "E404", "EPUBLISHCONFLICT", "EOTP"]);
 
+/**
+ * Codes that are the registry asking to be asked again.
+ *
+ * `E409` is here because the 4.2.0 release found it the hard way: 702 of 703
+ * packages published, and `@girs/unity-7.0` died on
+ *
+ *     npm error code E409
+ *     npm error 409 Conflict - PUT … - Failed to save packument. A common cause
+ *     is if you try to publish a new package before the previous package has
+ *     been fully published.
+ *
+ * — a transient write conflict, retried ZERO times, because tightening this
+ * classifier made it right about what is terminal and left everything it did
+ * not name unretryable. Being precise about one half of a partition is not the
+ * same as covering it.
+ *
+ * Publishing over an existing version is a DIFFERENT answer and stays terminal:
+ * npm spells that `EPUBLISHCONFLICT`, and `publishPackageOnce` resolves it as
+ * already-published before this is ever consulted.
+ */
+const RETRYABLE_NPM_CODES = new Set(["E409", "E500", "E502", "E503", "E504", "ETIMEDOUT", "ECONNRESET"]);
+
 function isTerminalNpmError(message: string): boolean {
 	const code = npmErrorCode(message);
 	return code !== null && TERMINAL_NPM_CODES.has(code);
+}
+
+function isRetryableNpmError(message: string): boolean {
+	const code = npmErrorCode(message);
+	return code !== null && RETRYABLE_NPM_CODES.has(code);
 }
 
 /**
@@ -144,7 +171,14 @@ function isTerminalNpmError(message: string): boolean {
  * Vector 2 is the incident, verbatim in shape: npm prints the tarball shasum on
  * every attempt, and `838bf765429e…` carries "429" at offset 8.
  */
-const CLASSIFIER_VECTORS: { name: string; message: string; rateLimited: boolean; terminal: boolean }[] = [
+const CLASSIFIER_VECTORS: {
+	name: string;
+	message: string;
+	rateLimited: boolean;
+	terminal: boolean;
+	/** Omitted means "not retryable" — the default for anything unnamed. */
+	retryable?: boolean;
+}[] = [
 	{
 		name: "E429 is a rate limit",
 		message: "npm error code E429\nnpm error 429 Too Many Requests",
@@ -173,10 +207,37 @@ const CLASSIFIER_VECTORS: { name: string; message: string; rateLimited: boolean;
 		terminal: false,
 	},
 	{
-		name: "a coded transport error is neither",
+		name: "a coded transport error is not a rate limit, and not terminal",
 		message: "npm error code ECONNRESET\nnpm error network socket hang up",
 		rateLimited: false,
 		terminal: false,
+		retryable: true,
+	},
+	{
+		// The 4.2.0 release: 702 of 703 published, this one retried zero times.
+		name: "E409 save-packument conflict is transient, so RETRYABLE",
+		message:
+			"npm error code E409\n" +
+			"npm error 409 Conflict - PUT https://registry.npmjs.org/@girs%2funity-7.0 - " +
+			"Failed to save packument. A common cause is if you try to publish a new package " +
+			"before the previous package has been fully published.",
+		rateLimited: false,
+		terminal: false,
+		retryable: true,
+	},
+	{
+		name: "publishing over an existing version is NOT the same conflict",
+		message: "npm error code EPUBLISHCONFLICT\nnpm error Cannot publish over existing version",
+		rateLimited: false,
+		terminal: true,
+		retryable: false,
+	},
+	{
+		name: "a 503 from the registry is retryable",
+		message: "npm error code E503\nnpm error 503 Service Unavailable",
+		rateLimited: false,
+		terminal: false,
+		retryable: true,
 	},
 	{
 		name: "an uncoded rate limit is still read, by phrase",
@@ -202,6 +263,9 @@ function selfTestClassifier(): void {
 		}
 		if (isTerminalNpmError(v.message) !== v.terminal) {
 			failures.push(`${v.name}: expected terminal=${v.terminal}`);
+		}
+		if (isRetryableNpmError(v.message) !== (v.retryable ?? false)) {
+			failures.push(`${v.name}: expected retryable=${v.retryable ?? false}`);
 		}
 	}
 	if (failures.length > 0) {
@@ -552,6 +616,7 @@ async function publishPackageWithRetry(pkg: Package, config: Config): Promise<vo
 				const lower = msg.toLowerCase();
 				return (
 					isRateLimitedError(msg) ||
+					isRetryableNpmError(msg) ||
 					lower.includes("econnreset") ||
 					lower.includes("etimedout") ||
 					lower.includes("socket hang up")


### PR DESCRIPTION
The 4.2.0 release published **702 of 703** packages over OIDC — no token in the repo at all — and
then failed the run, correctly, by the new rule that errors are reported whatever
`--continue-on-error` says. The one failure:

```
❌ @girs/unity-7.0
npm error code E409
npm error 409 Conflict - PUT https://registry.npmjs.org/@girs%2funity-7.0 -
  Failed to save packument. A common cause is if you try to publish a new package
  before the previous package has been fully published.
```

Retried **zero** times.

## The gap

That is one I introduced when tightening the classifier in #12. It became right about which codes
are TERMINAL — and left everything it did not name unretryable. Being precise about one half of a
partition is not the same as covering it, and the half I named was the half I had been bitten by,
which is exactly how the other half stays invisible.

So the retryable side is named too: `E409`, the 5xx family, and the coded transport errors.

Publishing **over an existing version** is a different answer and stays terminal — npm spells that
`EPUBLISHCONFLICT`, and `publishPackageOnce` resolves it as already-published before the
classifier is ever consulted. The two 409-shaped conditions must not collapse into one rule, so
there is now a control vector for each.

## Vectors

10, up from 7: the E409 message verbatim from the failing run, an `EPUBLISHCONFLICT` beside it, a
503, and the transport code. They run at startup, so they cannot rot.

A/B: emptying the retryable set fails three of them.

```
🧪 retry-classifier self-test green — 10 vector(s)
```

## The one package

`@girs/unity-7.0` is still at 4.1.0 and is picked up by any subsequent release run — the script
skips every version already on npm, so a re-run publishes exactly that one.