### PR TITLE
feat(sdk): publish a type bundle per Flatpak SDK

### DIFF
--- a/.github/release-script/src/index.ts
+++ b/.github/release-script/src/index.ts
@@ -10,6 +10,15 @@ interface Config {
 	dryRun: boolean;
 	continueOnError: boolean;
 	/**
+	 * Directory the sweep scans, relative to the repository root.
+	 *
+	 * Defaults to the repository root, which is every `@girs/*` namespace package. The SDK
+	 * channel bundles are generated into `sdk/` by a different workflow on a different cadence
+	 * and are not committed, so a sweep that always scanned everything would publish whichever
+	 * of the two happened to be on disk — and silently report success for the other.
+	 */
+	root: string;
+	/**
 	 * How this run authenticates to npm. BOTH are supported on purpose.
 	 *
 	 * `token` is the simple path and it stays: npm Trusted Publishing cannot
@@ -353,6 +362,7 @@ function showUsage(): void {
 	console.log("Options:");
 	console.log("  --dry-run, -d           Show what would be published without actually publishing");
 	console.log("  --continue-on-error, -c Continue processing even if some packages fail");
+	console.log("  --root <dir>            Scan only <dir> for packages (default: the whole repository)");
 	console.log("  --help, -h              Show this help message");
 	console.log("");
 	console.log("Environment variables:");
@@ -378,12 +388,30 @@ function getApiUrl(registry: string, packageName: string): string {
 	return `${baseUrl}${encodeURIComponent(packageName)}`;
 }
 
-function parseArgs(): Pick<Config, "dryRun" | "continueOnError"> {
+function parseArgs(): Pick<Config, "dryRun" | "continueOnError" | "root"> {
 	const args = process.argv;
 	return {
 		dryRun: args.includes("--dry-run") || args.includes("-d"),
 		continueOnError: args.includes("--continue-on-error") || args.includes("-c"),
+		root: parseRoot(args),
 	};
+}
+
+/**
+ * `--root <dir>` or `--root=<dir>`, relative to the repository root. Absolute paths and `..`
+ * are refused: this value decides what gets published, so it stays inside the repository.
+ */
+function parseRoot(args: string[]): string {
+	const inline = args.find((arg) => arg.startsWith("--root="));
+	const flagAt = args.indexOf("--root");
+	const raw = inline ? inline.slice("--root=".length) : flagAt >= 0 ? args[flagAt + 1] : undefined;
+
+	if (raw === undefined || raw === "") return ".";
+	if (raw.startsWith("-")) throw new Error("--root needs a directory argument");
+	if (raw.startsWith("/") || raw.split("/").includes("..")) {
+		throw new Error(`--root must stay inside the repository: ${raw}`);
+	}
+	return raw;
 }
 
 function getEnvConfig(): Pick<Config, "token" | "registry" | "timeoutSec"> {
@@ -648,10 +676,10 @@ async function publishPackageWithRetry(pkg: Package, config: Config): Promise<vo
 	}
 }
 
-async function collectPackages(): Promise<Package[]> {
+async function collectPackages(root: string): Promise<Package[]> {
 	// Get project root (3 levels up from .github/release-script/src/)
 	const scriptDir = new URL(".", import.meta.url).pathname;
-	const projectRoot = join(scriptDir, "..", "..", "..");
+	const projectRoot = join(scriptDir, "..", "..", "..", root);
 
 	console.log(`📁 Scanning ${projectRoot} for packages...`);
 
@@ -919,7 +947,7 @@ async function main(): Promise<void> {
 		console.log(`⚙️  Config: batch=${BATCH_SIZE}, batchDelay=${BATCH_DELAY_MS}ms, publishDelay=${PUBLISH_DELAY_MS}ms, statusConcurrency=${STATUS_CONCURRENCY}`);
 
 		await assertCanAuthenticate(config);
-		const packages = await collectPackages();
+		const packages = await collectPackages(config.root);
 
 		// Check for test packages with workspace dependencies
 		await checkForTestPackages(packages);

--- a/.github/sdk-channels/plan.mjs
+++ b/.github/sdk-channels/plan.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Decides, for ONE SDK channel, whether it has to be rebuilt and which version the rebuild
+// gets. Split from the workflow on purpose: this is the decision that makes a channel silently
+// stale (skip when it should have built) or a release silently empty (publish a version that
+// already exists, which `--tolerate-republish` reports as success), so it is a program with a
+// test rather than a shell expression inside a YAML step.
+//
+// There is deliberately NO state file. The registry is the state: the published manifest of a
+// channel carries the SDK commit it was generated from and the generator that produced it, so
+// the question "is this channel current?" is answered by the artifact itself and cannot drift
+// away from a checked-in copy of the answer.
+//
+// Usage:
+//   node plan.mjs --package @girs/sdk-gnome-50 --sdk-commit <hex> --generator 4.6.0
+//   → {"rebuild":true,"version":"4.6.0","reason":"never published"} on stdout,
+//     and the same fields appended to $GITHUB_OUTPUT when running in Actions.
+
+import { appendFileSync, realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const REGISTRY = process.env.NPM_REGISTRY || "https://registry.npmjs.org";
+
+/**
+ * @param {{sdk?: {commit?: string}, generator?: string} | null} published the manifest npm
+ *   currently serves for this channel, or null when the package does not exist yet
+ * @param {string} sdkCommit the flatpak commit of the SDK this run resolved
+ * @param {string} generatorVersion the ts-for-gir version this run will use
+ * @returns {{rebuild: boolean, reason: string}}
+ */
+export function decide(published, sdkCommit, generatorVersion) {
+  if (!published) return { rebuild: true, reason: "never published" };
+  if (published.sdk?.commit !== sdkCommit) {
+    return { rebuild: true, reason: `SDK moved: ${published.sdk?.commit ?? "unknown"} → ${sdkCommit}` };
+  }
+  if (published.generator !== generatorVersion) {
+    return { rebuild: true, reason: `generator moved: ${published.generator ?? "unknown"} → ${generatorVersion}` };
+  }
+  return { rebuild: false, reason: `up to date at ${sdkCommit.slice(0, 12)}` };
+}
+
+/**
+ * The channel's version line is the generator's `major.minor` with a build counter for its
+ * patch, because the two move independently: an SDK updates inside a GNOME cycle without the
+ * generator changing, and the generator releases without the SDK moving. Reusing the
+ * generator's full version would make the second case unpublishable.
+ *
+ * @param {string[]} publishedVersions every version npm already serves for this package
+ * @param {string} generatorVersion
+ * @returns {string}
+ */
+export function nextVersion(publishedVersions, generatorVersion) {
+  const match = /^(\d+)\.(\d+)\./.exec(generatorVersion);
+  if (!match) throw new Error(`generator version is not semver: ${generatorVersion}`);
+  const line = `${match[1]}.${match[2]}`;
+
+  const patches = publishedVersions
+    .map((version) => new RegExp(`^${line.replace(".", "\\.")}\\.(\\d+)$`).exec(version))
+    .filter((found) => found !== null)
+    .map((found) => Number.parseInt(found[1], 10));
+
+  return patches.length === 0 ? `${line}.0` : `${line}.${Math.max(...patches) + 1}`;
+}
+
+/**
+ * @param {string} packageName
+ * @returns {Promise<{versions: string[], latest: object | null}>}
+ */
+export async function readRegistry(packageName) {
+  const response = await fetch(`${REGISTRY}/${encodeURIComponent(packageName)}`);
+  if (response.status === 404) return { versions: [], latest: null };
+  if (!response.ok) {
+    throw new Error(`registry returned ${response.status} for ${packageName}`);
+  }
+  const packument = await response.json();
+  const versions = Object.keys(packument.versions ?? {});
+  const latestTag = packument["dist-tags"]?.latest;
+  return { versions, latest: latestTag ? (packument.versions[latestTag] ?? null) : null };
+}
+
+function argValue(name) {
+  const at = process.argv.indexOf(`--${name}`);
+  if (at < 0 || !process.argv[at + 1]) throw new Error(`missing --${name}`);
+  return process.argv[at + 1];
+}
+
+async function main() {
+  const packageName = argValue("package");
+  const sdkCommit = argValue("sdk-commit");
+  const generatorVersion = argValue("generator");
+
+  const { versions, latest } = await readRegistry(packageName);
+  const { rebuild, reason } = decide(latest, sdkCommit, generatorVersion);
+  const version = rebuild ? nextVersion(versions, generatorVersion) : (latest?.version ?? "");
+
+  const plan = { rebuild, version, reason };
+  console.log(JSON.stringify(plan));
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `rebuild=${rebuild}\nversion=${version}\nreason=${reason}\n`,
+    );
+  }
+}
+
+// Run as a program, importable as a module: the test imports `decide` and `nextVersion`
+// without the CLI trying to reach the registry.
+if (process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href) {
+  await main();
+}

--- a/.github/sdk-channels/plan.mjs
+++ b/.github/sdk-channels/plan.mjs
@@ -51,14 +51,20 @@ export function decide(published, sdkCommit, generatorVersion) {
 export function nextVersion(publishedVersions, generatorVersion) {
   const match = /^(\d+)\.(\d+)\./.exec(generatorVersion);
   if (!match) throw new Error(`generator version is not semver: ${generatorVersion}`);
-  const line = `${match[1]}.${match[2]}`;
+  const [, major, minor] = match;
 
+  // A constant pattern, compared field by field, rather than one built from `generatorVersion`.
+  // Building it would be a regex assembled from an argument — and the escaping that made it
+  // safe, `line.replace(".", "\\.")`, replaces only the FIRST dot, so it was one input away
+  // from meaning something else than it read.
   const patches = publishedVersions
-    .map((version) => new RegExp(`^${line.replace(".", "\\.")}\\.(\\d+)$`).exec(version))
-    .filter((found) => found !== null)
-    .map((found) => Number.parseInt(found[1], 10));
+    .map((version) => /^(\d+)\.(\d+)\.(\d+)$/.exec(version))
+    .filter((found) => found !== null && found[1] === major && found[2] === minor)
+    .map((found) => Number.parseInt(found[3], 10));
 
-  return patches.length === 0 ? `${line}.0` : `${line}.${Math.max(...patches) + 1}`;
+  return patches.length === 0
+    ? `${major}.${minor}.0`
+    : `${major}.${minor}.${Math.max(...patches) + 1}`;
 }
 
 /**

--- a/.github/sdk-channels/plan.test.mjs
+++ b/.github/sdk-channels/plan.test.mjs
@@ -1,0 +1,67 @@
+// The two decisions that can fail silently, held to cases that must go both ways.
+//
+// A channel that skips when it should build goes stale without a single red run, and a rebuild
+// that reuses an existing version is refused by npm as EPUBLISHCONFLICT — or, with a tolerant
+// publisher, reported as success while publishing nothing. Neither shows up in a log you would
+// read on a green run, so they are tested rather than watched.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { decide, nextVersion } from "./plan.mjs";
+
+const SDK = "c87589be513db588f67de1a27879315dc9697ed2bd8467bd3d55860bf4da2f42";
+const OTHER = "0000000000000000000000000000000000000000000000000000000000000000";
+
+test("a channel that was never published is built", () => {
+  const { rebuild, reason } = decide(null, SDK, "4.6.0");
+  assert.equal(rebuild, true);
+  assert.match(reason, /never published/);
+});
+
+test("a channel whose SDK and generator are unchanged is skipped", () => {
+  const published = { sdk: { commit: SDK }, generator: "4.6.0" };
+  assert.equal(decide(published, SDK, "4.6.0").rebuild, false);
+});
+
+test("a moved SDK rebuilds, even with the same generator", () => {
+  const published = { sdk: { commit: OTHER }, generator: "4.6.0" };
+  const { rebuild, reason } = decide(published, SDK, "4.6.0");
+  assert.equal(rebuild, true);
+  assert.match(reason, /SDK moved/);
+});
+
+test("a moved generator rebuilds, even with the same SDK", () => {
+  const published = { sdk: { commit: SDK }, generator: "4.5.0" };
+  const { rebuild, reason } = decide(published, SDK, "4.6.0");
+  assert.equal(rebuild, true);
+  assert.match(reason, /generator moved/);
+});
+
+test("a manifest without provenance rebuilds rather than assuming it matches", () => {
+  assert.equal(decide({}, SDK, "4.6.0").rebuild, true);
+});
+
+test("the first build of a generator line starts at .0", () => {
+  assert.equal(nextVersion([], "4.6.0"), "4.6.0");
+  assert.equal(nextVersion(["4.5.0", "4.5.1"], "4.6.0"), "4.6.0");
+});
+
+test("a further build of the same line takes the next free patch", () => {
+  assert.equal(nextVersion(["4.6.0"], "4.6.0"), "4.6.1");
+  assert.equal(nextVersion(["4.6.0", "4.6.1", "4.6.2"], "4.6.3"), "4.6.3");
+});
+
+test("the counter follows the highest patch, not the count", () => {
+  // A gap (a yanked or failed publish) must not hand out a version that already exists.
+  assert.equal(nextVersion(["4.6.0", "4.6.3"], "4.6.0"), "4.6.4");
+});
+
+test("versions from other lines and non-releases do not occupy the line", () => {
+  // A prerelease of the same number is a different version, so `4.6.0` is still free.
+  assert.equal(nextVersion(["4.5.9", "4.6.0-rc.1", "not-a-version"], "4.6.0"), "4.6.0");
+});
+
+test("a generator version that is not semver fails loudly", () => {
+  assert.throws(() => nextVersion([], "latest"), /not semver/);
+});

--- a/.github/workflows/sdk-types.yml
+++ b/.github/workflows/sdk-types.yml
@@ -49,7 +49,7 @@ jobs:
     outputs:
       matrix: ${{ steps.channels.outputs.matrix }}
       runtime: ${{ steps.channels.outputs.runtime }}
-      remote: ${{ steps.channels.outputs.remote }}
+      remotes: ${{ steps.channels.outputs.remotes }}
       generator: ${{ steps.generator.outputs.version }}
     steps:
       - uses: actions/checkout@v6
@@ -69,10 +69,15 @@ jobs:
             echo "no channel matches '${ONLY}'" >&2
             exit 1
           fi
+          # Every channel must name a remote the manifest defines; a typo here would
+          # otherwise surface as `flatpak install` failing against a remote that was never
+          # added, six steps later and under the wrong name.
+          jq -e '[.channels[].remote] - (.remotes | keys) | length == 0' sdk-channels.json > /dev/null \
+            || { echo "a channel names a remote that sdk-channels.json does not define" >&2; exit 1; }
           {
             echo "matrix=$matrix"
             echo "runtime=$(jq -r .runtime sdk-channels.json)"
-            echo "remote=$(jq -r .remote sdk-channels.json)"
+            echo "remotes=$(jq -c .remotes sdk-channels.json)"
           } >> "$GITHUB_OUTPUT"
 
       # Resolved once and passed to every leg: two legs of one run must not silently use
@@ -126,16 +131,29 @@ jobs:
           npm install -g npm@^11.5.1
           npm --version
 
+      # The remote comes from the channel, not from a global default: measured on 2026-09-05,
+      # stable `org.gnome.Sdk` on Flathub ends at 50, so `master` lives on gnome-nightly and a
+      # pre-release cycle on flathub-beta. One shared remote would install the wrong thing or
+      # nothing at all.
       - name: Install flatpak and the SDK
+        env:
+          REMOTES: ${{ needs.plan.outputs.remotes }}
+          REMOTE: ${{ matrix.channel.remote }}
+          REF: ${{ needs.plan.outputs.runtime }}//${{ matrix.channel.branch }}
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y flatpak
-          flatpak remote-add --if-not-exists --user \
-            ${{ needs.plan.outputs.remote }} https://dl.flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user --noninteractive --no-related \
-            ${{ needs.plan.outputs.remote }} \
-            ${{ needs.plan.outputs.runtime }}//${{ matrix.channel.branch }}
+          sudo apt-get install -y flatpak jq
+          url=$(jq -r --arg name "$REMOTE" '.[$name]' <<<"$REMOTES")
+          flatpak remote-add --if-not-exists --user "$REMOTE" "$url"
+          # A branch a remote does not carry is a declaration that ran ahead of reality — the
+          # usual case being a GNOME cycle added here before Flathub publishes it. Say which,
+          # rather than let `install` fail with a resolution error that names neither.
+          if ! flatpak remote-info --user "$REMOTE" "$REF" > /dev/null 2>&1; then
+            echo "$REMOTE does not carry $REF yet" >&2
+            exit 1
+          fi
+          flatpak install --user --noninteractive --no-related "$REMOTE" "$REF"
 
       # The SDK ships the GIR XML the Platform runtime does not, and it lies on disk as ordinary
       # files — no sandbox to enter, so the generator runs beside it with the normal toolchain.

--- a/.github/workflows/sdk-types.yml
+++ b/.github/workflows/sdk-types.yml
@@ -85,9 +85,33 @@ jobs:
 
       # Resolved once and passed to every leg: two legs of one run must not silently use
       # different generators, which is exactly what `@latest` per job would allow.
+      #
+      # A release dispatch names its own version, and it has to: `release-types.yml` (which
+      # sends it) and `release-app.yml` (which publishes the CLI) both fire on the SAME
+      # `release: published` event, so asking npm for `latest` here races the publish that is
+      # meant to have happened already. Waiting for the named version turns that race into a
+      # wait; every other trigger has no version in mind and asks for the current one.
       - name: Resolve the generator version
         id: generator
-        run: echo "version=$(npm view @ts-for-gir/cli version)" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE: ${{ github.event.client_payload.release }}
+        run: |
+          set -euo pipefail
+          if [ -n "${RELEASE:-}" ]; then
+            wanted="${RELEASE#v}"
+            echo "waiting for @ts-for-gir/cli@${wanted} to appear on the registry…"
+            for attempt in $(seq 1 40); do
+              if npm view "@ts-for-gir/cli@${wanted}" version > /dev/null 2>&1; then
+                echo "version=${wanted}" >> "$GITHUB_OUTPUT"
+                echo "::notice::generator ${wanted} (from the release dispatch, after ${attempt} check(s))"
+                exit 0
+              fi
+              sleep 30
+            done
+            echo "@ts-for-gir/cli@${wanted} did not appear within 20 minutes" >&2
+            exit 1
+          fi
+          echo "version=$(npm view @ts-for-gir/cli version)" >> "$GITHUB_OUTPUT"
 
       # A generator without `--bundle` does NOT fail on the flag — yargs ignores what it does
       # not know — it quietly emits per-namespace packages named `@girs/gtk-4.0` instead, into

--- a/.github/workflows/sdk-types.yml
+++ b/.github/workflows/sdk-types.yml
@@ -46,6 +46,9 @@ jobs:
   plan:
     name: Channels
     runs-on: ubuntu-24.04
+    # Reads the repository and the public registry, writes nothing.
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.channels.outputs.matrix }}
       runtime: ${{ steps.channels.outputs.runtime }}

--- a/.github/workflows/sdk-types.yml
+++ b/.github/workflows/sdk-types.yml
@@ -1,0 +1,210 @@
+# Publishes one `@girs/sdk-<runtime>-<branch>` package per Flatpak SDK channel: the whole GIR
+# set of that SDK, generated as ONE self-contained npm package (`ts-for-gir --bundle`).
+#
+# WHY A SEPARATE WORKFLOW. `release.yml` publishes the ~700 per-namespace packages from the
+# committed tree whenever this repository is pushed. The channels have neither property: they
+# are regenerated from a Flatpak SDK rather than committed (34 MB per channel, rebuilt monthly,
+# reproducible in seconds — the registry is the artifact store, this repository holds only the
+# recipe), and they move on their own cadence, because an SDK updates inside a GNOME cycle
+# without ts-for-gir releasing and ts-for-gir releases without the SDK moving.
+#
+# WHY NO STATE FILE. Each published channel manifest carries the SDK commit and the generator
+# version it was built from, so `plan.mjs` asks the registry whether a rebuild is due. A
+# checked-in copy of that answer would be a second truth that drifts.
+#
+# ADDING A CHANNEL is one line in `sdk-channels.json` — plus, once, `gjsify onboard` for the new
+# package name against THIS workflow file. npm Trusted Publishing can update a package but
+# cannot create one, and the 404 it fails with reads like a broken trusted publisher.
+name: SDK Types
+
+on:
+  # ts-for-gir released: every channel is rebuilt against the new generator.
+  repository_dispatch:
+    types: [generator-released]
+  # The SDKs move on their own: a weekly poll catches an SDK update inside a cycle. Channels
+  # whose SDK commit and generator are both unchanged cost one registry request and stop.
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Only this SDK branch (default: every channel in sdk-channels.json)"
+        required: false
+      dry_run:
+        description: "Generate and plan, publish nothing"
+        type: boolean
+        default: false
+
+concurrency:
+  group: npm-publish-sdk-types
+  cancel-in-progress: false
+
+env:
+  node-version: 24.x
+
+jobs:
+  plan:
+    name: Channels
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.channels.outputs.matrix }}
+      runtime: ${{ steps.channels.outputs.runtime }}
+      remote: ${{ steps.channels.outputs.remote }}
+      generator: ${{ steps.generator.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test the planning script
+        run: node --test .github/sdk-channels/plan.test.mjs
+
+      - name: Read sdk-channels.json
+        id: channels
+        env:
+          ONLY: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          matrix=$(jq -c --arg only "$ONLY" \
+            '[.channels[] | select($only == "" or .branch == $only)]' sdk-channels.json)
+          if [ "$(jq 'length' <<<"$matrix")" -eq 0 ]; then
+            echo "no channel matches '${ONLY}'" >&2
+            exit 1
+          fi
+          {
+            echo "matrix=$matrix"
+            echo "runtime=$(jq -r .runtime sdk-channels.json)"
+            echo "remote=$(jq -r .remote sdk-channels.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      # Resolved once and passed to every leg: two legs of one run must not silently use
+      # different generators, which is exactly what `@latest` per job would allow.
+      - name: Resolve the generator version
+        id: generator
+        run: echo "version=$(npm view @ts-for-gir/cli version)" >> "$GITHUB_OUTPUT"
+
+  channel:
+    name: ${{ matrix.channel.package }}
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.node-version }}
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      # npm >= 11.5.1 is a hard requirement for Trusted Publishing; below it a publish fails as
+      # an AUTH error, which reads like a broken trusted publisher rather than a stale npm.
+      - name: Pin an npm that can use Trusted Publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
+      - name: Install flatpak and the SDK
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y flatpak
+          flatpak remote-add --if-not-exists --user \
+            ${{ needs.plan.outputs.remote }} https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user --noninteractive --no-related \
+            ${{ needs.plan.outputs.remote }} \
+            ${{ needs.plan.outputs.runtime }}//${{ matrix.channel.branch }}
+
+      # The SDK ships the GIR XML the Platform runtime does not, and it lies on disk as ordinary
+      # files — no sandbox to enter, so the generator runs beside it with the normal toolchain.
+      - name: Locate the GIR files
+        id: sdk
+        run: |
+          set -euo pipefail
+          ref="${{ needs.plan.outputs.runtime }}//${{ matrix.channel.branch }}"
+          location=$(flatpak info --user --show-location "$ref")
+          girs="$location/files/share/gir-1.0"
+          count=$(find "$girs" -name '*.gir' | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "no GIR files under $girs — the SDK layout changed" >&2
+            exit 1
+          fi
+          {
+            echo "girs=$girs"
+            echo "commit=$(flatpak info --user --show-commit "$ref")"
+            echo "count=$count"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::$ref carries $count GIR files"
+
+      - name: Plan this channel
+        id: channel_plan
+        run: |
+          node .github/sdk-channels/plan.mjs \
+            --package '${{ matrix.channel.package }}' \
+            --sdk-commit '${{ steps.sdk.outputs.commit }}' \
+            --generator '${{ needs.plan.outputs.generator }}'
+
+      - name: Up to date
+        if: steps.channel_plan.outputs.rebuild != 'true'
+        run: echo "::notice::${{ matrix.channel.package }} skipped — ${{ steps.channel_plan.outputs.reason }}"
+
+      - name: Generate the bundle
+        if: steps.channel_plan.outputs.rebuild == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p sdk
+          npx --yes @ts-for-gir/cli@${{ needs.plan.outputs.generator }} generate '*' \
+            --girDirectories '${{ steps.sdk.outputs.girs }}' \
+            --outdir './sdk/${{ matrix.channel.branch }}' \
+            --bundle '${{ matrix.channel.package }}' \
+            --bundleMeta "$(jq -nc \
+              --arg id '${{ needs.plan.outputs.runtime }}' \
+              --arg branch '${{ matrix.channel.branch }}' \
+              --arg commit '${{ steps.sdk.outputs.commit }}' \
+              --arg generator '${{ needs.plan.outputs.generator }}' \
+              --arg version '${{ steps.channel_plan.outputs.version }}' \
+              '{sdk: {id: $id, branch: $branch, commit: $commit}, generator: $generator, version: $version}')" \
+            --ignoreVersionConflicts
+
+      # The manifest decides what is published, so it is checked before the sweep runs rather
+      # than trusted because the generator exited 0.
+      - name: Check the manifest
+        if: steps.channel_plan.outputs.rebuild == 'true'
+        run: |
+          set -euo pipefail
+          manifest="./sdk/${{ matrix.channel.branch }}/package.json"
+          node -e '
+            const [file, name, version, commit] = process.argv.slice(1);
+            const manifest = require(require("node:path").resolve(file));
+            const fail = (message) => { console.error(message); process.exit(1); };
+            if (manifest.name !== name) fail(`name ${manifest.name} != ${name}`);
+            if (manifest.version !== version) fail(`version ${manifest.version} != ${version}`);
+            if (manifest.sdk?.commit !== commit) fail("sdk.commit missing or wrong");
+            const subpaths = Object.keys(manifest.exports ?? {});
+            if (subpaths.length < 50) fail(`only ${subpaths.length} subpaths — the bundle is short`);
+            console.log(`${manifest.name}@${manifest.version}: ${subpaths.length} subpaths`);
+          ' "$manifest" '${{ matrix.channel.package }}' '${{ steps.channel_plan.outputs.version }}' '${{ steps.sdk.outputs.commit }}'
+
+      - name: Type-check the release script
+        if: steps.channel_plan.outputs.rebuild == 'true' && !inputs.dry_run
+        working-directory: .github/release-script
+        run: |
+          npm ci
+          npm run check
+
+      # Same publisher as release.yml, pointed at `sdk/` — including its retry policy and its
+      # refusal to treat "this version already exists" as success.
+      - name: Publish
+        if: steps.channel_plan.outputs.rebuild == 'true'
+        run: |
+          node --experimental-specifier-resolution=node --experimental-strip-types \
+            --experimental-transform-types --no-warnings \
+            ./.github/release-script/src/index.ts --root sdk ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/sdk-types.yml
+++ b/.github/workflows/sdk-types.yml
@@ -81,6 +81,22 @@ jobs:
         id: generator
         run: echo "version=$(npm view @ts-for-gir/cli version)" >> "$GITHUB_OUTPUT"
 
+      # A generator without `--bundle` does NOT fail on the flag — yargs ignores what it does
+      # not know — it quietly emits per-namespace packages named `@girs/gtk-4.0` instead, into
+      # a directory this workflow then hands to the publisher. The manifest check downstream
+      # would catch it, but only after a full generation and only by accident. Asked here, the
+      # answer is one line and the failure names the cause.
+      - name: Require a generator that can bundle
+        env:
+          GENERATOR: ${{ steps.generator.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! npx --yes "@ts-for-gir/cli@${GENERATOR}" generate --help | grep -q -- "--bundle"; then
+            echo "@ts-for-gir/cli@${GENERATOR} has no --bundle: the channels need a release that carries it" >&2
+            exit 1
+          fi
+          echo "::notice::generator ${GENERATOR} supports --bundle"
+
   channel:
     name: ${{ matrix.channel.package }}
     needs: plan

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+# SDK channel bundles: regenerated per run by sdk-types.yml, published to npm, never committed
+sdk/

--- a/sdk-channels.json
+++ b/sdk-channels.json
@@ -1,10 +1,15 @@
 {
   "$comment": "The SDK channels published from this repository. Adding a channel is a one-line change here plus one `gjsify onboard` bootstrap for the new package name — npm Trusted Publishing can update a package but cannot create one, and the 404 it fails with reads like a broken trusted publisher.",
   "runtime": "org.gnome.Sdk",
-  "remote": "flathub",
+  "$remotes": "Per channel, because they do not all live in the same place: measured against the Flathub OSTree repo on 2026-09-05, stable `org.gnome.Sdk` ends at 50 — `master` is only on gnome-nightly, and 51 exists so far only as `51beta` on flathub-beta.",
+  "remotes": {
+    "flathub": "https://dl.flathub.org/repo/flathub.flatpakrepo",
+    "flathub-beta": "https://dl.flathub.org/beta-repo/flathub-beta.flatpakrepo",
+    "gnome-nightly": "https://nightly.gnome.org/gnome-nightly.flatpakrepo"
+  },
   "channels": [
-    { "branch": "49", "package": "@girs/sdk-gnome-49" },
-    { "branch": "50", "package": "@girs/sdk-gnome-50" },
-    { "branch": "master", "package": "@girs/sdk-gnome-master" }
+    { "branch": "49", "remote": "flathub", "package": "@girs/sdk-gnome-49" },
+    { "branch": "50", "remote": "flathub", "package": "@girs/sdk-gnome-50" },
+    { "branch": "master", "remote": "gnome-nightly", "package": "@girs/sdk-gnome-master" }
   ]
 }

--- a/sdk-channels.json
+++ b/sdk-channels.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "The SDK channels published from this repository. Adding a channel is a one-line change here plus one `gjsify onboard` bootstrap for the new package name — npm Trusted Publishing can update a package but cannot create one, and the 404 it fails with reads like a broken trusted publisher.",
+  "runtime": "org.gnome.Sdk",
+  "remote": "flathub",
+  "channels": [
+    { "branch": "49", "package": "@girs/sdk-gnome-49" },
+    { "branch": "50", "package": "@girs/sdk-gnome-50" },
+    { "branch": "master", "package": "@girs/sdk-gnome-master" }
+  ]
+}


### PR DESCRIPTION
The published `@girs/*` set is generated from one GIR snapshot — today GNOME 51 development (`libraryVersion` 4.23.3 for Gtk). An app pinned to `gnome//50` (Gtk 4.22.4) is a cycle behind it and gets types offering APIs its runtime does not have. Asked for repeatedly, most recently from Workbench in gjsify/ts-for-gir#462.

This publishes one package per SDK channel: `@girs/sdk-gnome-49`, `@girs/sdk-gnome-50`, `@girs/sdk-gnome-master`. Each is the whole GIR set of that SDK, generated as ONE self-contained npm package by `ts-for-gir --bundle` (gjsify/ts-for-gir#463), so the set installs, resolves and versions as a unit. Per-namespace packages cannot give that: npm may satisfy `@girs/glib-2.0` from the registry for one namespace and from the pinned copy for another, and two copies of a namespace are duplicate `declare module 'gi://GLib'` blocks — ts-for-gir#431.

```jsonc
"devDependencies": { "@girs/sdk-gnome-50": "^4.6.0" }
```
```ts
import "@girs/sdk-gnome-50/gtk-4.0";
```

### Design

**Nothing is committed.** A channel is 34 MB, rebuilt monthly, and regenerates from the SDK in seconds — measured: `generate '*'` over `org.gnome.Sdk//50` is 11 s for 112 namespaces, 4.9 MB packed. The registry is the artifact store; this repository holds the recipe (`sdk-channels.json`, the workflow, the planner). `sdk/` is gitignored.

**No state file.** Every published channel manifest carries the SDK commit and generator version it came from, so `plan.mjs` asks the registry whether a rebuild is due. A checked-in copy of that answer is a second truth that drifts. Custom manifest fields do survive into the registry — verified: `npm view @girs/gtk-4.0 libraryVersion` → `4.23.3`.

**A separate workflow,** because the cadences differ: `release.yml` sweeps the committed tree on every push, while an SDK updates inside a GNOME cycle without ts-for-gir releasing, and ts-for-gir releases without the SDK moving. Hence a weekly poll plus a `generator-released` dispatch from ts-for-gir. The publisher is the same hardened script, given a `--root` so each sweep publishes exactly the tree it means to.

**The SDK needs no sandbox.** `org.gnome.Sdk//50` ships 113 GIR XML files (the Platform runtime ships only typelibs), and they lie on disk as ordinary files — the generator runs beside them with the normal toolchain.

### Tests

`plan.mjs` makes the two decisions that fail silently when wrong: a skip that should have built goes stale on a green run, and a version that already exists is refused as EPUBLISHCONFLICT or reported as a successful no-op. Ten cases cover both directions of each — never published, unchanged, SDK moved, generator moved, missing provenance, first patch, next patch, a gap in the line, prereleases, and a non-semver generator. One of them already corrected a wrong assumption of mine.

### Before the first run

`@girs/sdk-gnome-*` are new names, and Trusted Publishing can update a package but cannot create one — the 404 reads like a broken trusted publisher. Each needs one `gjsify onboard` bootstrap against `sdk-types.yml` (not `release.yml`). Worth a `--dry-run` dispatch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvMH98Xsfh6rAJK5HRfxFq

---

## Channel availability, measured 2026-09-05

Queried against the Flathub OSTree repo directly (the local `flathub` remote is a filtered Fedora one and cannot answer this):

| Branch | Where | In this PR |
|---|---|---|
| `49`, `50` | flathub, stable | yes |
| `master` | **gnome-nightly**, not flathub | yes |
| `51` | nowhere yet — stable `org.gnome.Sdk` ends at 50 | no |
| `51beta` | flathub-beta | no |

That is why the remote moved from a single global value into each channel: `master` against `flathub` would have failed at `flatpak install`. GNOME 51 is due mid-September; adding it is one line here plus one `gjsify onboard` run for `@girs/sdk-gnome-51`.

## Bootstrap

The three bundles are generated locally and validated, so the bootstrap is a single command. Dry-run output:

```
gjsify onboard: root=…/types-release | packages(sdk/*)=3
gjsify onboard: 3 of 3 package(s) selected | repo=gjsify/types workflow=sdk-types.yml
Plan: 0 already done, 3 to publish+trust, 0 to trust, 0 unreadable.
```

`--packages 'sdk/*'` scopes discovery to the bundles, so the 704 existing `@girs/*` packages are not touched.

| Channel | GIRs | Namespaces | Subpaths | Gtk | Adw |
|---|---|---|---|---|---|
| `@girs/sdk-gnome-49` | 112 | 113 | 458 | 4.20.4 | 1.8.7 |
| `@girs/sdk-gnome-50` | 112 | 113 | 458 | 4.22.4 | 1.9.3 |
| `@girs/sdk-gnome-master` | 116 | 117 | 474 | 4.23.4 | 1.10.0 |

Each packs to ~5.0 MB (34 MB unpacked, 916 files for `50`).
